### PR TITLE
Fixing merchant purchases

### DIFF
--- a/src/game.htm
+++ b/src/game.htm
@@ -1967,7 +1967,7 @@ __\\_______^/
             }
 
             player.bitcoins -= item.price.buy;
-            player.inventory[itemKey] = (player.inventory?.[itemKey] || 0) + 1;
+            player.inventory.contents[itemKey] = (player.inventory?.contents[itemKey] || 0) + 1;
 
             playSFX('kaching');
 


### PR DESCRIPTION
The merchant would take your money, but items would not show up in the player's inventory

This is because the items were being put into `player.inventory` which is the entire inventory plus functional data rather than `player.inventory.contents` which is where the item list actually lives

This PR solves the problem by referencing the correct location for inventory storage after purchase

### Testing
1. Check your inventory and note its contents
2. Visit the merchant
3. Buy items from him
4. Leave
5. Open your inventory again
6. Observe that the content count matches what was seen previously, plus whatever what purchased from the merchant

Resolves https://github.com/packardbell95/tardquest/issues/25