### PR TITLE
Added inventory submenus

### DIFF
--- a/src/game.htm
+++ b/src/game.htm
@@ -433,9 +433,11 @@
                 torch: 2,
                 brickOfC4: 2,
                 dowsingRod: 2,
+                fingerNail: 1, //Start game with this in inventory
+                pectoralMass: 1, //Start game with this in inventory
             },
-            weapon: 'fingerNail',
-            armor: 'pectoralMass',
+            weapon: 'fingerNail', //Start game with this equipped
+            armor: 'pectoralMass', //Start game with this equipped
             movementDisabled: false,
         };
 
@@ -455,38 +457,39 @@
                 merchant.say('AIEEEEEEEEEEEEEE!');
                 updateBattleLog('HOLY SHIT! The <span class="friendly">merchant</span> has been <span class="action">vaporized</span> into a bloody red mist!');
             },
-            buy: function(type, key) {
-                const merchandise = (type === 'item' ? items : (type === 'weapon' ? weapons : armor))?.[key];
-                if (!merchandise) {
-                    console.error(`${key} doesn't exist!`);
-                    return;
-                }
+        buy: function(type, key) {
+            const merchandise = (type === 'item' ? items : (type === 'weapon' ? weapons : armor))?.[key];
+            if (!merchandise) {
+                console.error(`${key} doesn't exist!`);
+                return;
+            }
 
-                if (player.bitcoins < merchandise.price) {
-                    merchant.say('Too bad, kid. Come back when you get some coin!');
-                    return;
-                }
+            if (player.bitcoins < merchandise.price) {
+                merchant.say('Too bad, kid. Come back when you get some coin!');
+                return;
+            }
 
-                player.bitcoins -= merchandise.price;
-                playSFX('kaching');
+            // Prevent buying equipment you already own
+            if (type !== 'item' && (player.inventory[key] > 0 || player[type] === key)) {
+                merchant.say("You already own that, stupid!");
+                return;
+            }
 
-                if (type === 'item') {
-                    player.inventory[key] = (player.inventory?.[key] || 0) + 1;
-                } else {
-                    player.inventory[key] = (player.inventory?.[key] || 0) + 1;
-                    player[type] = key;
-                }
+            player.bitcoins -= merchandise.price;
+            playSFX('kaching');
+            // Disable equipment auto equip upon purchase
+            player.inventory[key] = (player.inventory?.[key] || 0) + 1;
 
-                const purchaseFlavorText = [
-                    "HAHA! You won't regret it!",
-                    "Don't forget: NO REFUNDS!",
-                    "You won't find a better deal than this!",
-                ];
-                const merchantText = purchaseFlavorText[Math.floor(Math.random() * purchaseFlavorText.length)];
-                merchant.say(merchantText);
+            const purchaseFlavorText = [
+                "HAHA! You won't regret it!",
+                "Don't forget: NO REFUNDS!",
+                "You won't find a better deal than this!",
+            ];
+            const merchantText = purchaseFlavorText[Math.floor(Math.random() * purchaseFlavorText.length)];
+            merchant.say(merchantText);
 
-                const merchandiseText = getArticle(merchandise.name) + merchandise.name;
-                updateBattleLog(`You just bought ${merchandiseText}`);
+            const merchandiseText = getArticle(merchandise.name) + merchandise.name;
+            updateBattleLog(`You just bought ${merchandiseText}`);
             }
         };
 
@@ -2378,6 +2381,14 @@ __\\_______^/
                     document.getElementById('game').classList.remove('hidden');
                 }
             },
+            closeAll: () => {
+                while (menu.breadcrumbs.length > 0) {
+                    const previousMenu = menu.breadcrumbs.pop();
+                    menu.menus[previousMenu.menuName].onClose?.();
+                }
+                document.getElementById('menu').classList.add('hidden');
+                document.getElementById('game').classList.remove('hidden');
+            },
             render: () => {
                 let menuHtml = "";
                 const activeMenu = menu.getActiveMenu();
@@ -2465,8 +2476,11 @@ __\\_______^/
                     case 'e':
                     case 'enter':
                         const selectedOptionId = options[menu.currentPage * itemsPerPage + menu.selectionIndex]?.id;
-                        if (selectedOptionId === '_exit') {
+                        if (selectedOptionId === '_back') {
                             menu.close();
+                            playSFX('uiCancel');
+                        } else if (selectedOptionId === '_exitAll') {
+                            menu.closeAll();
                             playSFX('uiCancel');
                         } else {
                             activeMenu.select(selectedOptionId);
@@ -2497,17 +2511,13 @@ __\\_______^/
                             description: "View and change your equipped weapon and armor.",
                         },
                         {
-                            id: "_exit",
+                            id: "_back",
                             displayText: "[Back]",
                             description: "Get back to playing the game",
                         }
                     ],
                     select: (selectedOptionId) => {
-                        if (selectedOptionId === "_exit") {
-                            menu.close();
-                        } else {
-                            menu.open(selectedOptionId);
-                        }
+                        menu.open(selectedOptionId);
                     },
                 },
                 inventoryItems: {
@@ -2528,7 +2538,7 @@ __\\_______^/
                             }));
 
                         options.push({
-                            id: "_exit",
+                            id: "_back",
                             displayText: "[Back]",
                             description: "Return to the inventory menu",
                         });
@@ -2536,11 +2546,13 @@ __\\_______^/
                         return options;
                     },
                     select: (selectedOptionId) => {
-                        if (selectedOptionId === "_exit") {
+                        if (selectedOptionId === "_back") {
                             menu.close();
+                        } else if (selectedOptionId === "_exitAll") {
+                            menu.closeAll();
                         } else {
                             useItem(selectedOptionId);
-                            menu.close();
+                            menu.closeAll(); // Close all menus after using an item
                             if (currentEnemy && currentEnemy.hp > 0) {
                                 enemyAttack();
                                 render();
@@ -2560,27 +2572,23 @@ __\\_______^/
                         return [
                             {
                                 id: "equipHand",
-                                displayText: `Hand: ${weapon ? weapon.name : "None"}`,
+                                displayText: `Hand: ${weapon?.name || "None"}`,
                                 description: "View and equip your weapons.",
                             },
                             {
                                 id: "equipBody",
-                                displayText: `Body: ${armorPiece ? armorPiece.name : "None"}`,
+                                displayText: `Body: ${armorPiece?.name || "None"}`,
                                 description: "View and equip your armor.",
                             },
                             {
-                                id: "_exit",
+                                id: "_back",
                                 displayText: "[Back]",
                                 description: "Return to the inventory menu",
                             }
                         ];
                     },
                     select: (selectedOptionId) => {
-                        if (selectedOptionId === "_exit") {
-                            menu.close();
-                        } else {
-                            menu.open(selectedOptionId);
-                        }
+                        menu.open(selectedOptionId);
                     },
                 },
                 equipHand: {
@@ -2596,11 +2604,11 @@ __\\_______^/
                                 `${weapons[weaponId].description}\n` +
                                 `Base Damage: ${weapons[weaponId].damage.base}, ` +
                                 `Random Multiplier: ${weapons[weaponId].damage.randomMultiplier}`,
-                            className: player.weapon === weaponId ? "action" : undefined,
+                            className: player.weapon === weaponId ? "friendly" : undefined,
                         }));
 
                         options.push({
-                            id: "_exit",
+                            id: "_back",
                             displayText: "[Back]",
                             description: "Return to equipment menu",
                         });
@@ -2608,7 +2616,7 @@ __\\_______^/
                         return options;
                     },
                     select: (selectedOptionId) => {
-                        if (selectedOptionId === "_exit") {
+                        if (selectedOptionId === "_back") {
                             menu.close();
                         } else {
                             player.weapon = selectedOptionId;
@@ -2630,11 +2638,11 @@ __\\_______^/
                             description:
                                 `${armor[armorId].description}\n` +
                                 `Defense: ${armor[armorId].defense}`,
-                            className: player.armor === armorId ? "action" : undefined,
+                            className: player.armor === armorId ? "friendly" : undefined,
                         }));
 
                         options.push({
-                            id: "_exit",
+                            id: "_back",
                             displayText: "[Back]",
                             description: "Return to equipment menu",
                         });
@@ -2642,7 +2650,7 @@ __\\_______^/
                         return options;
                     },
                     select: (selectedOptionId) => {
-                        if (selectedOptionId === "_exit") {
+                        if (selectedOptionId === "_back") {
                             menu.close();
                         } else {
                             player.armor = selectedOptionId;
@@ -2682,7 +2690,7 @@ __\\_______^/
                                 description: "Get some thicker skin",
                             },
                             {
-                                id: "_exit",
+                                id: "_back",
                                 displayText: "Leave",
                                 description: "Get back to spelunking",
                             },
@@ -2710,7 +2718,7 @@ __\\_______^/
                         }));
 
                         options.push({
-                            id: "_exit",
+                            id: "_back",
                             displayText: "Back",
                             description: "Return to the merchant menu",
                         });
@@ -2738,6 +2746,7 @@ __\\_______^/
                         const weaponKeys = Object.keys(weapons);
                         const options = weaponKeys.map((weaponId) => {
                             const tooExpensive = weapons[weaponId].price > player.bitcoins;
+                            const alreadyOwned = player.inventory[weaponId] > 0 || player.weapon === weaponId;
                             return {
                                 id: weaponId,
                                 displayText: weapons[weaponId].name,
@@ -2746,13 +2755,13 @@ __\\_______^/
                                     `Base Damage: ${weapons[weaponId].damage.base}, ` +
                                     `Random Multiplier: ${weapons[weaponId].damage.randomMultiplier}`,
                                 trailText: `${weapons[weaponId].price} BTC`,
-                                disabled: tooExpensive,
-                                className: tooExpensive ? 'tooExpensive' : undefined,
+                                disabled: tooExpensive || alreadyOwned,
+                                className: alreadyOwned ? 'muted' : (tooExpensive ? 'tooExpensive' : undefined),
                             };
                         });
 
                         options.push({
-                            id: "_exit",
+                            id: "_back",
                             displayText: "Back",
                             description: "Return to the merchant menu",
                         });
@@ -2780,6 +2789,7 @@ __\\_______^/
                         const armorKeys = Object.keys(armor);
                         const options = armorKeys.map((armorId) => {
                             const tooExpensive = armor[armorId].price > player.bitcoins;
+                            const alreadyOwned = player.inventory[armorId] > 0 || player.armor === armorId;
                             return {
                                 id: armorId,
                                 displayText: armor[armorId].name,
@@ -2787,13 +2797,13 @@ __\\_______^/
                                     `${armor[armorId].description}\n` +
                                     `Defense: ${armor[armorId].defense}`,
                                 trailText: `${armor[armorId].price} BTC`,
-                                disabled: tooExpensive,
-                                className: tooExpensive ? 'tooExpensive' : undefined,
+                                disabled: tooExpensive || alreadyOwned,
+                                className: alreadyOwned ? 'muted' : (tooExpensive ? 'tooExpensive' : undefined),
                             };
                         });
 
                         options.push({
-                            id: "_exit",
+                            id: "_back",
                             displayText: "Back",
                             description: "Return to the merchant menu",
                         });
@@ -2832,7 +2842,7 @@ __\\_______^/
                                 description: "Take your chance with the gambler",
                             },
                             {
-                                id: "_exit",
+                                id: "_back",
                                 displayText: "Leave",
                                 description: "Leave this crusty fool",
                             },
@@ -2859,7 +2869,7 @@ You found a treasure chest! Do you want to open it?
                                 description: "Claim your succulent reward!",
                             },
                             {
-                                id: "_exit",
+                                id: "_back",
                                 displayText: "Resist your burning temptation...",
                                 description: "DON'T claim your succulent reward!",
                             },

--- a/src/game.htm
+++ b/src/game.htm
@@ -175,7 +175,21 @@
             font-weight: bold;
             line-height: 1.0;
         }
+        .stats-container {
+            text-align: center;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            line-height: 1;
+            margin: 0;
+        }
 
+        .stats-label {
+            font-size: 14px;
+            margin-top: 2px;
+            margin-bottom: 0;
+            padding: 0;
+        }
         #battleLog,
         #minimap {
             background: #000;
@@ -208,16 +222,29 @@
 
         #inputBox {
             display: none;
-            /* This ensures it's hidden initially */
+        }
+        #inputBox input::placeholder {
+            color: #d8d8d8;
+            opacity: 1;
         }
 
         #inputBox input {
-            background-color: black;
             color: white;
-            border: none;
             font-size: 13px;
-            width: 210px;
+            width: 600px;
+            height: 2px;
             z-index: 9;
+            font-family: monospace;
+            background-color: #000;
+            border: 3px dotted #A23AB4;
+            padding: 10px;
+            font-size: 16px;
+            border-radius: 0px;
+            text-align: left;
+            position: absolute;
+            top: 125px;
+            left: 58px;
+            outline: none;
         }
 
         .menus {
@@ -407,8 +434,8 @@
                 brickOfC4: 2,
                 dowsingRod: 2,
             },
-            weapon: 'pointyStick',
-            armor: 'graphicTee',
+            weapon: 'fingerNail',
+            armor: 'pectoralMass',
             movementDisabled: false,
         };
 
@@ -431,7 +458,7 @@
             buy: function(type, key) {
                 const merchandise = (type === 'item' ? items : (type === 'weapon' ? weapons : armor))?.[key];
                 if (!merchandise) {
-                    console.error(`${itemKey} doesn't exist!`);
+                    console.error(`${key} doesn't exist!`);
                     return;
                 }
 
@@ -446,6 +473,7 @@
                 if (type === 'item') {
                     player.inventory[key] = (player.inventory?.[key] || 0) + 1;
                 } else {
+                    player.inventory[key] = (player.inventory?.[key] || 0) + 1;
                     player[type] = key;
                 }
 
@@ -577,6 +605,15 @@
         ];
 
         const weapons = {
+            fingerNail: {
+                name: "FINGERNAIL",
+                description: "Your very own fingernail! Careful not to break it!",
+                damage: {
+                    base: 1,
+                    randomMultiplier: 4,
+                },
+                price: 0,
+            },
             pointyStick: {
                 name: "POINTY STICK",
                 description: "A stick that fell off of a tree somewhere",
@@ -652,10 +689,16 @@
         };
 
         const armor = {
+            pectoralMass: {
+                name: "PECTORAL MASS",
+                description: "Your totally big, meaty pectorals! You're not fat at all...'",
+                defense: 1,
+                price: 0,
+            },
             graphicTee: {
                 name: "GRAPHIC TEE",
                 description: "A t-shirt that says 'Normal people scare me'",
-                defense: 1,
+                defense: 2,
                 price: 20,
             },
             barrelWithSuspenders: {
@@ -1588,14 +1631,21 @@ __\\_______^/
             drawMinimap();
             let output = "";
 
-            const stats1Html = `<div center>.-STATS-.</div>
-            <div style="text-align:center; display:flex; flex-direction:column; align-items:center; line-height:1;"><span>|===<span class="HP">HP</span>===|</span><span style="font-size:0.95em; margin-top:2px;">${player.hp}/${player.maxHp}</span>
-            <div style="text-align:center; display:flex; flex-direction:column; align-items:center; line-height:1;"><span>|==<span class="DEF">DEF</span>==|</span><span style="font-size:0.95em; margin-top:2px;">${player.defense}</span>
-            <div style="text-align:center; display:flex; flex-direction:column; align-items:center; line-height:1;"><span>|==<span class="PRS">PRS</span>==|</span><span style="font-size:0.95em; margin-top:2px;">${player.persuasion}</span>
-            <div style="text-align:center; display:flex; flex-direction:column; align-items:center; line-height:1;"><span>|==<span class="SPD">SPD</span>==|</span><span style="font-size:0.95em; margin-top:2px;">${player.speed}</span>
-            <div style="text-align:center; display:flex; flex-direction:column; align-items:center; line-height:1;"><span>|==<span class="LUK">LUK</span>==|</span><span style="font-size:0.95em; margin-top:2px;">${player.luck}</span>
-            <span center>._ _ _ _.</span>
-            `;
+        const stats1Html = `
+        <div class="stats-container">
+            <span>.-STATS-.</span>
+            <span>|===<span class="HP">HP</span>===|</span>
+            <span class="stats-label">${player.hp}/${player.maxHp}</span>
+            <span>|==<span class="DEF">DEF</span>==|</span>
+            <span class="stats-label">${player.defense}</span>
+            <span>|==<span class="PRS">PRS</span>==|</span>
+            <span class="stats-label">${player.persuasion}</span>
+            <span>|==<span class="SPD">SPD</span>==|</span>
+            <span class="stats-label">${player.speed}</span>
+            <span>|==<span class="LUK">LUK</span>==|</span>
+            <span class="stats-label">${player.luck}</span>
+            <span>._ _ _ _.</span>
+        </div>`;
             document.getElementById('stats1').innerHTML = stats1Html;
 
             const stats2Html = `<div style="text-align:center; display:flex; flex-direction:column; align-items:center; line-height:1;"><span>.---<span class="action">FLOOR</span>---.</span><span style="font-size:0.95em; margin-top:2px;">${floor}</span>
@@ -1987,11 +2037,12 @@ __\\_______^/
 
 
         function useItem(itemName) {
-            items[itemName].use();
-
-            player.inventory[itemName]--;
-            if (player.inventory[itemName] <= 0) {
-                delete player.inventory[itemName];
+            if (items[itemName] && typeof items[itemName].use === "function") {
+                items[itemName].use();
+                player.inventory[itemName]--;
+                if (player.inventory[itemName] <= 0) {
+                    delete player.inventory[itemName];
+                }
             }
 
             render();
@@ -2434,28 +2485,169 @@ __\\_______^/
                             ? 'You own nothing. Klaus Schwab would be proud'
                             : null;
                     },
+                    getOptions: () => [
+                        {
+                            id: "inventoryItems",
+                            displayText: "Items",
+                            description: "View your consumable items.",
+                        },
+                        {
+                            id: "inventoryEquipment",
+                            displayText: "Equipment",
+                            description: "View and change your equipped weapon and armor.",
+                        },
+                        {
+                            id: "_exit",
+                            displayText: "[Back]",
+                            description: "Get back to playing the game",
+                        }
+                    ],
+                    select: (selectedOptionId) => {
+                        if (selectedOptionId === "_exit") {
+                            menu.close();
+                        } else {
+                            menu.open(selectedOptionId);
+                        }
+                    },
+                },
+                inventoryItems: {
+                    title: "ITEMS",
+                    landingHtml: () => {
+                        return isEmpty(player.inventory)
+                            ? 'You own nothing. Klaus Schwab would be proud'
+                            : null;
+                    },
                     getOptions: () => {
-                        const options = Object.keys(player.inventory).map((itemId) => ({
-                            id: itemId,
-                            displayText: items[itemId].name,
-                            description: items[itemId].description,
-                            trailText: `${player.inventory[itemId]}`,
-                        }));
+                        const options = Object.keys(player.inventory)
+                            .filter(itemId => items[itemId])
+                            .map((itemId) => ({
+                                id: itemId,
+                                displayText: items[itemId].name,
+                                description: items[itemId].description,
+                                trailText: `${player.inventory[itemId]}`,
+                            }));
 
                         options.push({
                             id: "_exit",
-                            displayText: "Exit the Inventory",
-                            description: "Get back to playing the game",
+                            displayText: "[Back]",
+                            description: "Return to the inventory menu",
                         });
 
                         return options;
                     },
                     select: (selectedOptionId) => {
-                        useItem(selectedOptionId);
-                        menu.close();
-                        if (currentEnemy && currentEnemy.hp > 0) {
-                            enemyAttack();
-                            render();
+                        if (selectedOptionId === "_exit") {
+                            menu.close();
+                        } else {
+                            useItem(selectedOptionId);
+                            menu.close();
+                            if (currentEnemy && currentEnemy.hp > 0) {
+                                enemyAttack();
+                                render();
+                            }
+                        }
+                    },
+                },
+                inventoryEquipment: {
+                    title: "EQUIPMENT",
+                    landingHtml: () => {
+                        const weapon = weapons[player.weapon];
+                        const armorPiece = armor[player.armor];
+                    },
+                    getOptions: () => {
+                        const weapon = weapons[player.weapon];
+                        const armorPiece = armor[player.armor];
+                        return [
+                            {
+                                id: "equipHand",
+                                displayText: `Hand: ${weapon ? weapon.name : "None"}`,
+                                description: "View and equip your weapons.",
+                            },
+                            {
+                                id: "equipBody",
+                                displayText: `Body: ${armorPiece ? armorPiece.name : "None"}`,
+                                description: "View and equip your armor.",
+                            },
+                            {
+                                id: "_exit",
+                                displayText: "[Back]",
+                                description: "Return to the inventory menu",
+                            }
+                        ];
+                    },
+                    select: (selectedOptionId) => {
+                        if (selectedOptionId === "_exit") {
+                            menu.close();
+                        } else {
+                            menu.open(selectedOptionId);
+                        }
+                    },
+                },
+                equipHand: {
+                    title: "EQUIP WEAPON",
+                    landingHtml: () => {
+                    },
+                    getOptions: () => {
+                        const ownedWeapons = Object.keys(weapons).filter(w => player.inventory[w] > 0 || player.weapon === w);
+                        const options = ownedWeapons.map((weaponId) => ({
+                            id: weaponId,
+                            displayText: weapons[weaponId].name + (player.weapon === weaponId ? " (Equipped)" : ""),
+                            description:
+                                `${weapons[weaponId].description}\n` +
+                                `Base Damage: ${weapons[weaponId].damage.base}, ` +
+                                `Random Multiplier: ${weapons[weaponId].damage.randomMultiplier}`,
+                            className: player.weapon === weaponId ? "action" : undefined,
+                        }));
+
+                        options.push({
+                            id: "_exit",
+                            displayText: "[Back]",
+                            description: "Return to equipment menu",
+                        });
+
+                        return options;
+                    },
+                    select: (selectedOptionId) => {
+                        if (selectedOptionId === "_exit") {
+                            menu.close();
+                        } else {
+                            player.weapon = selectedOptionId;
+                            updateBattleLog(`You now wield a mighty <span class="friendly">${weapons[selectedOptionId].name}</span>! You feel like you're ready to take some dumbass kid's lunch money... sicko.`);
+                            menu.close();
+                        }
+                    },
+                },
+
+                equipBody: {
+                    title: "EQUIP ARMOR",
+                    landingHtml: () => {
+                    },
+                    getOptions: () => {
+                        const ownedArmor = Object.keys(armor).filter(a => player.inventory[a] > 0 || player.armor === a);
+                        const options = ownedArmor.map((armorId) => ({
+                            id: armorId,
+                            displayText: armor[armorId].name + (player.armor === armorId ? " (Equipped)" : ""),
+                            description:
+                                `${armor[armorId].description}\n` +
+                                `Defense: ${armor[armorId].defense}`,
+                            className: player.armor === armorId ? "action" : undefined,
+                        }));
+
+                        options.push({
+                            id: "_exit",
+                            displayText: "[Back]",
+                            description: "Return to equipment menu",
+                        });
+
+                        return options;
+                    },
+                    select: (selectedOptionId) => {
+                        if (selectedOptionId === "_exit") {
+                            menu.close();
+                        } else {
+                            player.armor = selectedOptionId;
+                            updateBattleLog(`You are now wearing <span class="friendly">${armor[selectedOptionId].name}</span>! You know what they say about wearing protection...`);
+                            menu.close();
                         }
                     },
                 },
@@ -2546,8 +2738,6 @@ __\\_______^/
                         const weaponKeys = Object.keys(weapons);
                         const options = weaponKeys.map((weaponId) => {
                             const tooExpensive = weapons[weaponId].price > player.bitcoins;
-                            const notAnUpgrade = weaponKeys.indexOf(player.weapon) >= weaponKeys.indexOf(weaponId);
-
                             return {
                                 id: weaponId,
                                 displayText: weapons[weaponId].name,
@@ -2556,8 +2746,8 @@ __\\_______^/
                                     `Base Damage: ${weapons[weaponId].damage.base}, ` +
                                     `Random Multiplier: ${weapons[weaponId].damage.randomMultiplier}`,
                                 trailText: `${weapons[weaponId].price} BTC`,
-                                disabled: tooExpensive || notAnUpgrade,
-                                className: notAnUpgrade ? 'muted' : (tooExpensive ? 'tooExpensive' : undefined),
+                                disabled: tooExpensive,
+                                className: tooExpensive ? 'tooExpensive' : undefined,
                             };
                         });
 
@@ -2590,8 +2780,6 @@ __\\_______^/
                         const armorKeys = Object.keys(armor);
                         const options = armorKeys.map((armorId) => {
                             const tooExpensive = armor[armorId].price > player.bitcoins;
-                            const notAnUpgrade = armorKeys.indexOf(player.armor) >= armorKeys.indexOf(armorId);
-
                             return {
                                 id: armorId,
                                 displayText: armor[armorId].name,
@@ -2599,8 +2787,8 @@ __\\_______^/
                                     `${armor[armorId].description}\n` +
                                     `Defense: ${armor[armorId].defense}`,
                                 trailText: `${armor[armorId].price} BTC`,
-                                disabled: tooExpensive || notAnUpgrade,
-                                className: notAnUpgrade ? 'muted' : (tooExpensive ? 'tooExpensive' : undefined),
+                                disabled: tooExpensive,
+                                className: tooExpensive ? 'tooExpensive' : undefined,
                             };
                         });
 


### PR DESCRIPTION
The player is now able to manually equip obtained weapons and armor, meaning submenus were also added to the inventory screen. Now when you open the inventory, you can select the "Equipment" or "Items" menu. I've pretty much removed the "notAnUpgrade" logic from equipment purchases so you can actually own all the pieces you buy, rather than it working like a linear upgrade system. I kept the .muted id though in case we do still want to use it for something in the future. One minor but annoying issue I ran into was that when you first buy something from the merchant, you lose the armor/item you start the game off with. Could not figure out how to fix that, so my sorry workaround was the create new starting equipment that is weaker, but can still be bought for free if you really wanted to for some reason. Do let me know how this can be fixed though.
![1](https://github.com/user-attachments/assets/c3252923-cb12-4ab1-92f4-8af03a919705)
![2](https://github.com/user-attachments/assets/252b60a8-f10a-4514-9611-8c1009954c70)
![3](https://github.com/user-attachments/assets/f18d3ad3-5ee8-480a-b0f3-44ee91cdf1d9)
I think we should have a good setup now for when we eventually add rings to the game.

I also consolidated the stats panel stylings into their own classes to keep that shit clean

This will close #33 