### PR TITLE
Extending display height to allow side walls to be taller

### DIFF
--- a/src/game.htm
+++ b/src/game.htm
@@ -105,7 +105,6 @@
             position: absolute;
             top: 0;
             left: 0;
-            margin-top: 3em;
         }
 
         #game > .layer:nth-child(1) > span { color: rgb(42, 42, 42); }
@@ -628,7 +627,7 @@
                 positions: {
                     p1_1: {
                         artIndex: 0,
-                        drawAt: { x: 6, y: 1 },
+                        drawAt: { x: 6, y: 4 },
                     },
                 },
                 art: [
@@ -648,108 +647,108 @@
                 positions: {
                     p0_0: {
                         artIndex: 0,
-                        drawAt: { x: 0, y: 0 },
+                        drawAt: { x: 0, y: 1 },
                     },
                     p0_2: {
                         artIndex: 0,
                         drawOptions: { flippedX: true },
-                        drawAt: { x: 44, y: 0 },
+                        drawAt: { x: 44, y: 1 },
                     },
                     p1_0: {
                         artIndex: 1,
-                        drawAt: { x: 0, y: 1 },
+                        drawAt: { x: 0, y: 4 },
                     },
                     p1_1: {
                         artIndex: 2,
-                        drawAt: { x: 5, y: 1 },
+                        drawAt: { x: 5, y: 4 },
                     },
                     p1_2: {
                         artIndex: 1,
                         drawOptions: { flippedX: true },
-                        drawAt: { x: 35, y: 1 },
+                        drawAt: { x: 35, y: 4 },
                     },
                     p2_0: {
                         artIndex: 3,
-                        drawAt: { x: 0, y: 6 },
+                        drawAt: { x: 0, y: 9 },
                     },
                     p2_1: {
                         artIndex: 4,
-                        drawAt: { x: 0, y: 5 },
+                        drawAt: { x: 0, y: 8 },
                     },
                     p2_2: {
                         artIndex: 5,
-                        drawAt: { x: 14, y: 5 },
+                        drawAt: { x: 14, y: 8 },
                     },
                     p2_3: {
                         artIndex: 4,
                         drawOptions: { flippedX: true },
-                        drawAt: { x: 30, y: 5 },
+                        drawAt: { x: 30, y: 8 },
                     },
                     p2_4: {
                         artIndex: 3,
                         drawOptions: { flippedX: true },
-                        drawAt: { x: 41, y: 6 },
+                        drawAt: { x: 41, y: 9 },
                     },
                     p3_0: {
                         artIndex: 6,
-                        drawAt: { x: 0, y: 9 },
+                        drawAt: { x: 0, y: 12 },
                     },
                     p3_1: {
                         artIndex: 7,
-                        drawAt: { x: -3, y: 8 },
+                        drawAt: { x: -3, y: 11 },
                     },
                     p3_2: {
                         artIndex: 7,
-                        drawAt: { x: 8, y: 8 },
+                        drawAt: { x: 8, y: 11 },
                     },
                     p3_3: {
                         artIndex: 8,
-                        drawAt: { x: 19, y: 8 },
+                        drawAt: { x: 19, y: 11 },
                     },
                     p3_4: {
                         artIndex: 7,
                         drawOptions: { flippedX: true },
-                        drawAt: { x: 27, y: 8 },
+                        drawAt: { x: 27, y: 11 },
                     },
                     p3_5: {
                         artIndex: 7,
                         drawOptions: { flippedX: true },
-                        drawAt: { x: 34, y: 8 },
+                        drawAt: { x: 34, y: 11 },
                     },
                     p3_6: {
                         artIndex: 6,
                         drawOptions: { flippedX: true },
-                        drawAt: { x: 46, y: 9 },
+                        drawAt: { x: 46, y: 12 },
                     },
                     p4_0: {
                         artIndex: 9,
-                        drawAt: { x: 2, y: 9 },
+                        drawAt: { x: 2, y: 12 },
                     },
                     p4_1: {
                         artIndex: 9,
-                        drawAt: { x: 7, y: 9 },
+                        drawAt: { x: 7, y: 12 },
                     },
                     p4_2: {
                         artIndex: 10,
-                        drawAt: { x: 12, y: 9 },
+                        drawAt: { x: 12, y: 12 },
                     },
                     p4_3: {
                         artIndex: 11,
-                        drawAt: { x: 17, y: 9 },
+                        drawAt: { x: 17, y: 12 },
                     },
                     p4_4: {
                         artIndex: 12,
-                        drawAt: { x: 22, y: 9 },
+                        drawAt: { x: 22, y: 12 },
                     },
                     p4_5: {
                         artIndex: 11,
                         drawOptions: { flippedX: true },
-                        drawAt: { x: 26, y: 9 },
+                        drawAt: { x: 26, y: 12 },
                     },
                     p4_6: {
                         artIndex: 10,
                         drawOptions: { flippedX: true },
-                        drawAt: { x: 30, y: 9 },
+                        drawAt: { x: 30, y: 12 },
                     },
                     p4_7: {
                         artIndex: 9,
@@ -759,57 +758,59 @@
                     p4_8: {
                         artIndex: 9,
                         drawOptions: { flippedX: true },
-                        drawAt: { x: 40, y: 9 },
+                        drawAt: { x: 40, y: 12 },
                     },
                     p5_0: {
                         artIndex: 13,
-                        drawAt: { x: 14, y: 10 },
+                        drawAt: { x: 14, y: 13 },
                     },
                     p5_1: {
                         artIndex: 13,
-                        drawAt: { x: 16, y: 10 },
+                        drawAt: { x: 16, y: 13 },
                     },
                     p5_2: {
                         artIndex: 13,
-                        drawAt: { x: 18, y: 10 },
+                        drawAt: { x: 18, y: 13 },
                     },
                     p5_3: {
                         artIndex: 13,
-                        drawAt: { x: 20, y: 10 },
+                        drawAt: { x: 20, y: 13 },
                     },
                     p5_4: {
                         artIndex: 13,
-                        drawAt: { x: 22, y: 10 },
+                        drawAt: { x: 22, y: 13 },
                     },
                     p5_5: {
                         artIndex: 13,
-                        drawAt: { x: 24, y: 10 },
+                        drawAt: { x: 24, y: 13 },
                     },
                     p5_6: {
                         artIndex: 13,
-                        drawAt: { x: 26, y: 10 },
+                        drawAt: { x: 26, y: 13 },
                     },
                     p5_7: {
                         artIndex: 13,
-                        drawAt: { x: 28, y: 10 },
+                        drawAt: { x: 28, y: 13 },
                     },
                     p5_8: {
                         artIndex: 13,
-                        drawAt: { x: 30, y: 10 },
+                        drawAt: { x: 30, y: 13 },
                     },
                     p5_9: {
                         artIndex: 13,
-                        drawAt: { x: 32, y: 10 },
+                        drawAt: { x: 32, y: 13 },
                     },
                     p5_10: {
                         artIndex: 13,
-                        drawAt: { x: 34, y: 10 },
+                        drawAt: { x: 34, y: 13 },
                     },
                 },
                 art: [
                     {
                         automaskBlockCharacters: true,
                         data: `
+                            ▄
+                            ██▄
                             ████▄
                             ██████
                             ██████
@@ -832,6 +833,8 @@
                             ██████
                             ██████
                             ████▀
+                            ██▀
+                            ▀
                         `,
                     },
                     {
@@ -1014,162 +1017,162 @@
                 positions: {
                     p0_0: {
                         artIndex: 0,
-                        drawAt: { x: 0, y: 11 },
+                        drawAt: { x: 0, y: 14 },
                     },
                     p0_2: {
                         artIndex: 0,
                         drawOptions: { flippedX: true },
-                        drawAt: { x: 45, y: 11 },
+                        drawAt: { x: 45, y: 14 },
                     },
                     p1_0: {
                         artIndex: 1,
-                        drawAt: { x: 0, y: 11 },
+                        drawAt: { x: 0, y: 14 },
                     },
                     p1_1: {
                         artIndex: 2,
-                        drawAt: { x: 5, y: 11 },
+                        drawAt: { x: 5, y: 14 },
                     },
                     p1_2: {
                         artIndex: 1,
                         drawOptions: { flippedX: true },
-                        drawAt: { x: 36, y: 11 },
+                        drawAt: { x: 36, y: 14 },
                     },
                     p2_0: {
                         artIndex: 3,
-                        drawAt: { x: 0, y: 11 },
+                        drawAt: { x: 0, y: 14 },
                     },
                     p2_1: {
                         artIndex: 4,
-                        drawAt: { x: 0, y: 11 },
+                        drawAt: { x: 0, y: 14 },
                     },
                     p2_2: {
                         artIndex: 5,
-                        drawAt: { x: 14, y: 11 },
+                        drawAt: { x: 14, y: 14 },
                     },
                     p2_3: {
                         artIndex: 4,
                         drawOptions: { flippedX: true },
-                        drawAt: { x: 31, y: 11 },
+                        drawAt: { x: 31, y: 14 },
                     },
                     p2_4: {
                         artIndex: 3,
                         drawOptions: { flippedX: true },
-                        drawAt: { x: 42, y: 11 },
+                        drawAt: { x: 42, y: 14 },
                     },
                     p3_0: {
                         artIndex: 6,
-                        drawAt: { x: 0, y: 11 },
+                        drawAt: { x: 0, y: 14 },
                     },
                     p3_1: {
                         artIndex: 7,
-                        drawAt: { x: -3, y: 11 },
+                        drawAt: { x: -3, y: 14 },
                     },
                     p3_2: {
                         artIndex: 7,
-                        drawAt: { x: 8, y: 11 },
+                        drawAt: { x: 8, y: 14 },
                     },
                     p3_3: {
                         artIndex: 8,
-                        drawAt: { x: 19, y: 11 },
+                        drawAt: { x: 19, y: 14 },
                     },
                     p3_4: {
                         artIndex: 7,
                         drawOptions: { flippedX: true },
-                        drawAt: { x: 28, y: 11 },
+                        drawAt: { x: 28, y: 14 },
                     },
                     p3_5: {
                         artIndex: 7,
                         drawOptions: { flippedX: true },
-                        drawAt: { x: 35, y: 11 },
+                        drawAt: { x: 35, y: 14 },
                     },
                     p3_6: {
                         artIndex: 6,
                         drawOptions: { flippedX: true },
-                        drawAt: { x: 47, y: 11 },
+                        drawAt: { x: 47, y: 14 },
                     },
                     p4_0: {
                         artIndex: 9,
-                        drawAt: { x: 2, y: 11 },
+                        drawAt: { x: 2, y: 14 },
                     },
                     p4_1: {
                         artIndex: 9,
-                        drawAt: { x: 7, y: 11 },
+                        drawAt: { x: 7, y: 14 },
                     },
                     p4_2: {
                         artIndex: 10,
-                        drawAt: { x: 12, y: 11 },
+                        drawAt: { x: 12, y: 14 },
                     },
                     p4_3: {
                         artIndex: 11,
-                        drawAt: { x: 17, y: 11 },
+                        drawAt: { x: 17, y: 14 },
                     },
                     p4_4: {
                         artIndex: 12,
-                        drawAt: { x: 22, y: 11 },
+                        drawAt: { x: 22, y: 14 },
                     },
                     p4_5: {
                         artIndex: 11,
                         drawOptions: { flippedX: true },
-                        drawAt: { x: 27, y: 11 },
+                        drawAt: { x: 27, y: 14 },
                     },
                     p4_6: {
                         artIndex: 10,
                         drawOptions: { flippedX: true },
-                        drawAt: { x: 31, y: 11 },
+                        drawAt: { x: 31, y: 14 },
                     },
                     p4_7: {
                         artIndex: 9,
                         drawOptions: { flippedX: true },
-                        drawAt: { x: 36, y: 11 },
+                        drawAt: { x: 36, y: 14 },
                     },
                     p4_8: {
                         artIndex: 9,
                         drawOptions: { flippedX: true },
-                        drawAt: { x: 41, y: 11 },
+                        drawAt: { x: 41, y: 14 },
                     },
                     p5_0: {
                         artIndex: 13,
-                        drawAt: { x: 14, y: 11 },
+                        drawAt: { x: 14, y: 14 },
                     },
                     p5_1: {
                         artIndex: 13,
-                        drawAt: { x: 16, y: 11 },
+                        drawAt: { x: 16, y: 14 },
                     },
                     p5_2: {
                         artIndex: 13,
-                        drawAt: { x: 18, y: 11 },
+                        drawAt: { x: 18, y: 14 },
                     },
                     p5_3: {
                         artIndex: 13,
-                        drawAt: { x: 20, y: 11 },
+                        drawAt: { x: 20, y: 14 },
                     },
                     p5_4: {
                         artIndex: 13,
-                        drawAt: { x: 22, y: 11 },
+                        drawAt: { x: 22, y: 14 },
                     },
                     p5_5: {
                         artIndex: 13,
-                        drawAt: { x: 24, y: 11 },
+                        drawAt: { x: 24, y: 14 },
                     },
                     p5_6: {
                         artIndex: 13,
-                        drawAt: { x: 26, y: 11 },
+                        drawAt: { x: 26, y: 14 },
                     },
                     p5_7: {
                         artIndex: 13,
-                        drawAt: { x: 28, y: 11 },
+                        drawAt: { x: 28, y: 14 },
                     },
                     p5_8: {
                         artIndex: 13,
-                        drawAt: { x: 30, y: 11 },
+                        drawAt: { x: 30, y: 14 },
                     },
                     p5_9: {
                         artIndex: 13,
-                        drawAt: { x: 32, y: 11 },
+                        drawAt: { x: 32, y: 14 },
                     },
                     p5_10: {
                         artIndex: 13,
-                        drawAt: { x: 34, y: 11 },
+                        drawAt: { x: 34, y: 14 },
                     },
                 },
                 art: [
@@ -1315,168 +1318,170 @@
                 positions: {
                     p0_0: {
                         artIndex: 0,
-                        drawAt: { x: 0, y: 0 },
+                        drawAt: { x: 0, y: 1 },
                     },
                     p0_2: {
                         artIndex: 0,
                         drawOptions: { flippedX: true },
-                        drawAt: { x: 44, y: 0 },
+                        drawAt: { x: 44, y: 1 },
                     },
                     p1_0: {
                         artIndex: 1,
-                        drawAt: { x: 0, y: 1 },
+                        drawAt: { x: 0, y: 4 },
                     },
                     p1_1: {
                         artIndex: 2,
-                        drawAt: { x: 5, y: 1 },
+                        drawAt: { x: 5, y: 4 },
                     },
                     p1_2: {
                         artIndex: 1,
                         drawOptions: { flippedX: true },
-                        drawAt: { x: 35, y: 1 },
+                        drawAt: { x: 35, y: 4 },
                     },
                     p2_0: {
                         artIndex: 3,
-                        drawAt: { x: 0, y: 6 },
+                        drawAt: { x: 0, y: 9 },
                     },
                     p2_1: {
                         artIndex: 4,
-                        drawAt: { x: 0, y: 5 },
+                        drawAt: { x: 0, y: 8 },
                     },
                     p2_2: {
                         artIndex: 5,
-                        drawAt: { x: 14, y: 5 },
+                        drawAt: { x: 14, y: 8 },
                     },
                     p2_3: {
                         artIndex: 4,
                         drawOptions: { flippedX: true },
-                        drawAt: { x: 30, y: 5 },
+                        drawAt: { x: 30, y: 8 },
                     },
                     p2_4: {
                         artIndex: 3,
                         drawOptions: { flippedX: true },
-                        drawAt: { x: 41, y: 6 },
+                        drawAt: { x: 41, y: 9 },
                     },
                     p3_0: {
                         artIndex: 6,
-                        drawAt: { x: 0, y: 9 },
+                        drawAt: { x: 0, y: 12 },
                     },
                     p3_1: {
                         artIndex: 7,
-                        drawAt: { x: -3, y: 8 },
+                        drawAt: { x: -3, y: 11 },
                     },
                     p3_2: {
                         artIndex: 7,
-                        drawAt: { x: 8, y: 8 },
+                        drawAt: { x: 8, y: 11 },
                     },
                     p3_3: {
                         artIndex: 8,
-                        drawAt: { x: 19, y: 8 },
+                        drawAt: { x: 19, y: 11 },
                     },
                     p3_4: {
                         artIndex: 7,
                         drawOptions: { flippedX: true },
-                        drawAt: { x: 27, y: 8 },
+                        drawAt: { x: 27, y: 11 },
                     },
                     p3_5: {
                         artIndex: 7,
                         drawOptions: { flippedX: true },
-                        drawAt: { x: 34, y: 8 },
+                        drawAt: { x: 34, y: 11 },
                     },
                     p3_6: {
                         artIndex: 6,
                         drawOptions: { flippedX: true },
-                        drawAt: { x: 46, y: 9 },
+                        drawAt: { x: 46, y: 12 },
                     },
                     p4_0: {
                         artIndex: 9,
-                        drawAt: { x: 2, y: 9 },
+                        drawAt: { x: 2, y: 12 },
                     },
                     p4_1: {
                         artIndex: 9,
-                        drawAt: { x: 7, y: 9 },
+                        drawAt: { x: 7, y: 12 },
                     },
                     p4_2: {
                         artIndex: 10,
-                        drawAt: { x: 12, y: 9 },
+                        drawAt: { x: 12, y: 12 },
                     },
                     p4_3: {
                         artIndex: 11,
-                        drawAt: { x: 17, y: 9 },
+                        drawAt: { x: 17, y: 12 },
                     },
                     p4_4: {
                         artIndex: 12,
-                        drawAt: { x: 22, y: 9 },
+                        drawAt: { x: 22, y: 12 },
                     },
                     p4_5: {
                         artIndex: 11,
                         drawOptions: { flippedX: true },
-                        drawAt: { x: 26, y: 9 },
+                        drawAt: { x: 26, y: 12 },
                     },
                     p4_6: {
                         artIndex: 10,
                         drawOptions: { flippedX: true },
-                        drawAt: { x: 30, y: 9 },
+                        drawAt: { x: 30, y: 12 },
                     },
                     p4_7: {
                         artIndex: 9,
                         drawOptions: { flippedX: true },
-                        drawAt: { x: 35, y: 9 },
+                        drawAt: { x: 35, y: 12 },
                     },
                     p4_8: {
                         artIndex: 9,
                         drawOptions: { flippedX: true },
-                        drawAt: { x: 40, y: 9 },
+                        drawAt: { x: 40, y: 12 },
                     },
                     p5_0: {
                         artIndex: 13,
-                        drawAt: { x: 14, y: 10 },
+                        drawAt: { x: 14, y: 13 },
                     },
                     p5_1: {
                         artIndex: 13,
-                        drawAt: { x: 16, y: 10 },
+                        drawAt: { x: 16, y: 13 },
                     },
                     p5_2: {
                         artIndex: 13,
-                        drawAt: { x: 18, y: 10 },
+                        drawAt: { x: 18, y: 13 },
                     },
                     p5_3: {
                         artIndex: 13,
-                        drawAt: { x: 20, y: 10 },
+                        drawAt: { x: 20, y: 13 },
                     },
                     p5_4: {
                         artIndex: 13,
-                        drawAt: { x: 22, y: 10 },
+                        drawAt: { x: 22, y: 13 },
                     },
                     p5_5: {
                         artIndex: 13,
-                        drawAt: { x: 24, y: 10 },
+                        drawAt: { x: 24, y: 13 },
                     },
                     p5_6: {
                         artIndex: 13,
-                        drawAt: { x: 26, y: 10 },
+                        drawAt: { x: 26, y: 13 },
                     },
                     p5_7: {
                         artIndex: 13,
-                        drawAt: { x: 28, y: 10 },
+                        drawAt: { x: 28, y: 13 },
                     },
                     p5_8: {
                         artIndex: 13,
-                        drawAt: { x: 30, y: 10 },
+                        drawAt: { x: 30, y: 13 },
                     },
                     p5_9: {
                         artIndex: 13,
-                        drawAt: { x: 32, y: 10 },
+                        drawAt: { x: 32, y: 13 },
                     },
                     p5_10: {
                         artIndex: 13,
-                        drawAt: { x: 34, y: 10 },
+                        drawAt: { x: 34, y: 13 },
                     },
                 },
                 art: [
                     {
                         automaskBlockCharacters: true,
                         data: `
+                            ▄
+                            ██▄
                             ████▄
                             ██████
                             ██████
@@ -1499,6 +1504,8 @@
                             ██████
                             ██████
                             ████▀
+                            ██▀
+                            ▀
                         `,
                     },
                     {
@@ -1681,155 +1688,155 @@
                 positions: {
                     p0_0: {
                         artIndex: 0,
-                        drawAt: { x: -19, y: 21 },
+                        drawAt: { x: -19, y: 24 },
                     },
                     p0_2: {
                         artIndex: 0,
-                        drawAt: { x: 45, y: 21 },
+                        drawAt: { x: 45, y: 24 },
                     },
                     p1_0: {
                         artIndex: 0,
-                        drawAt: { x: -12, y: 17 },
+                        drawAt: { x: -12, y: 20 },
                     },
                     p1_1: {
                         artIndex: 1,
-                        drawAt: { x: 8, y: 17 },
+                        drawAt: { x: 8, y: 20 },
                     },
                     p1_2: {
                         artIndex: 0,
-                        drawAt: { x: 38, y: 17 },
+                        drawAt: { x: 38, y: 20 },
                     },
                     p2_0: {
                         artIndex: 2,
-                        drawAt: { x: 0, y: 15 },
+                        drawAt: { x: 0, y: 18 },
                     },
                     p2_1: {
                         artIndex: 3,
-                        drawAt: { x: 3, y: 14 },
+                        drawAt: { x: 3, y: 17 },
                     },
                     p2_2: {
                         artIndex: 4,
-                        drawAt: { x: 16, y: 14 },
+                        drawAt: { x: 16, y: 17 },
                     },
                     p2_3: {
                         artIndex: 5,
-                        drawAt: { x: 32, y: 14 },
+                        drawAt: { x: 32, y: 17 },
                     },
                     p2_4: {
                         artIndex: 2,
                         drawOptions: { flippedX: true },
-                        drawAt: { x: 42, y: 15 },
+                        drawAt: { x: 42, y: 18 },
                     },
                     p3_0: {
                         artIndex: 10,
-                        drawAt: { x: -9, y: 12 },
+                        drawAt: { x: -9, y: 15 },
                     },
                     p3_1: {
                         artIndex: 10,
-                        drawAt: { x: -3, y: 13 },
+                        drawAt: { x: -3, y: 16 },
                     },
                     p3_2: {
                         artIndex: 10,
-                        drawAt: { x: 8, y: 13 },
+                        drawAt: { x: 8, y: 16 },
                     },
                     p3_3: {
                         artIndex: 7,
-                        drawAt: { x: 20, y: 13 },
+                        drawAt: { x: 20, y: 16 },
                     },
                     p3_4: {
                         artIndex: 10,
                         drawOptions: { flippedX: true },
-                        drawAt: { x: 29, y: 13 },
+                        drawAt: { x: 29, y: 16 },
                     },
                     p3_5: {
                         artIndex: 10,
                         drawOptions: { flippedX: true },
-                        drawAt: { x: 36, y: 13 },
+                        drawAt: { x: 36, y: 16 },
                     },
                     p3_6: {
                         artIndex: 10,
                         drawOptions: { flippedX: true },
-                        drawAt: { x: 46, y: 12 },
+                        drawAt: { x: 46, y: 15 },
                     },
                     p4_0: {
                         artIndex: 8,
-                        drawAt: { x: 2, y: 12 },
+                        drawAt: { x: 2, y: 15 },
                     },
                     p4_1: {
                         artIndex: 8,
-                        drawAt: { x: 7, y: 12 },
+                        drawAt: { x: 7, y: 15 },
                     },
                     p4_2: {
                         artIndex: 8,
-                        drawAt: { x: 12, y: 12 },
+                        drawAt: { x: 12, y: 15 },
                     },
                     p4_3: {
                         artIndex: 8,
-                        drawAt: { x: 17, y: 12 },
+                        drawAt: { x: 17, y: 15 },
                     },
                     p4_4: {
                         artIndex: 8,
-                        drawAt: { x: 22, y: 12 },
+                        drawAt: { x: 22, y: 15 },
                     },
                     p4_5: {
                         artIndex: 8,
-                        drawAt: { x: 27, y: 12 },
+                        drawAt: { x: 27, y: 15 },
                     },
                     p4_6: {
                         artIndex: 8,
-                        drawAt: { x: 32, y: 12 },
+                        drawAt: { x: 32, y: 15 },
                     },
                     p4_7: {
                         artIndex: 8,
-                        drawAt: { x: 37, y: 12 },
+                        drawAt: { x: 37, y: 15 },
                     },
                     p4_8: {
                         artIndex: 8,
-                        drawAt: { x: 42, y: 12 },
+                        drawAt: { x: 42, y: 15 },
                     },
                     p5_0: {
                         artIndex: 9,
-                        drawAt: { x: 14, y: 11 },
+                        drawAt: { x: 14, y: 14 },
                     },
                     p5_1: {
                         artIndex: 9,
-                        drawAt: { x: 16, y: 11 },
+                        drawAt: { x: 16, y: 14 },
                     },
                     p5_2: {
                         artIndex: 9,
-                        drawAt: { x: 18, y: 11 },
+                        drawAt: { x: 18, y: 14 },
                     },
                     p5_3: {
                         artIndex: 9,
-                        drawAt: { x: 20, y: 11 },
+                        drawAt: { x: 20, y: 14 },
                     },
                     p5_4: {
                         artIndex: 9,
-                        drawAt: { x: 22, y: 11 },
+                        drawAt: { x: 22, y: 14 },
                     },
                     p5_5: {
                         artIndex: 9,
-                        drawAt: { x: 24, y: 11 },
+                        drawAt: { x: 24, y: 14 },
                     },
                     p5_6: {
                         artIndex: 9,
-                        drawAt: { x: 26, y: 11 },
+                        drawAt: { x: 26, y: 14 },
                     },
                     p5_7: {
                         artIndex: 9,
-                        drawAt: { x: 28, y: 11 },
+                        drawAt: { x: 28, y: 14 },
                     },
                     p5_8: {
                         artIndex: 9,
-                        drawAt: { x: 30, y: 11 },
+                        drawAt: { x: 30, y: 14 },
                     },
                     p5_9: {
                         artIndex: 9,
-                        drawAt: { x: 32, y: 11 },
+                        drawAt: { x: 32, y: 14 },
                     },
                     p5_10: {
                         artIndex: 9,
-                        drawAt: { x: 34, y: 11 },
+                        drawAt: { x: 34, y: 14 },
                     },
                 },
                 art: [
@@ -1922,151 +1929,151 @@
                 positions: {
                     p0_0: {
                         artIndex: 0,
-                        drawAt: { x: -28, y: 4 },
+                        drawAt: { x: -28, y: 7 },
                     },
                     p0_2: {
                         artIndex: 0,
-                        drawAt: { x: 45, y: 4 },
+                        drawAt: { x: 45, y: 7 },
                     },
                     p1_0: {
                         artIndex: 0,
-                        drawAt: { x: -25, y: 1 },
+                        drawAt: { x: -25, y: 4 },
                     },
                     p1_1: {
                         artIndex: 0,
-                        drawAt: { x: 7, y: 1 },
+                        drawAt: { x: 7, y: 4 },
                     },
                     p1_2: {
                         artIndex: 0,
-                        drawAt: { x: 39, y: 1 },
+                        drawAt: { x: 39, y: 4 },
                     },
                     p2_0: {
                         artIndex: 1,
-                        drawAt: { x: -7, y: 11 },
+                        drawAt: { x: -7, y: 14 },
                     },
                     p2_1: {
                         artIndex: 1,
-                        drawAt: { x: 3, y: 6 },
+                        drawAt: { x: 3, y: 9 },
                     },
                     p2_2: {
                         artIndex: 2,
-                        drawAt: { x: 16, y: 6 },
+                        drawAt: { x: 16, y: 9 },
                     },
                     p2_3: {
                         artIndex: 3,
-                        drawAt: { x: 30, y: 6 },
+                        drawAt: { x: 30, y: 9 },
                     },
                     p2_4: {
                         artIndex: 3,
-                        drawAt: { x: 42, y: 7 },
+                        drawAt: { x: 42, y: 10 },
                     },
                     p3_0: {
                         artIndex: 4,
-                        drawAt: { x: -9, y: 12 },
+                        drawAt: { x: -9, y: 15 },
                     },
                     p3_1: {
                         artIndex: 4,
-                        drawAt: { x: -3, y: 8 },
+                        drawAt: { x: -3, y: 11 },
                     },
                     p3_2: {
                         artIndex: 4,
-                        drawAt: { x: 8, y: 8 },
+                        drawAt: { x: 8, y: 11 },
                     },
                     p3_3: {
                         artIndex: 5,
-                        drawAt: { x: 20, y: 8 },
+                        drawAt: { x: 20, y: 11 },
                     },
                     p3_4: {
                         artIndex: 6,
-                        drawAt: { x: 29, y: 8 },
+                        drawAt: { x: 29, y: 11 },
                     },
                     p3_5: {
                         artIndex: 6,
-                        drawAt: { x: 36, y: 8 },
+                        drawAt: { x: 36, y: 11 },
                     },
                     p3_6: {
                         artIndex: 6,
-                        drawAt: { x: 46, y: 9 },
+                        drawAt: { x: 46, y: 12 },
                     },
                     p4_0: {
                         artIndex: 7,
-                        drawAt: { x: 2, y: 9 },
+                        drawAt: { x: 2, y: 12 },
                     },
                     p4_1: {
                         artIndex: 7,
-                        drawAt: { x: 7, y: 9 },
+                        drawAt: { x: 7, y: 12 },
                     },
                     p4_2: {
                         artIndex: 7,
-                        drawAt: { x: 12, y: 9 },
+                        drawAt: { x: 12, y: 12 },
                     },
                     p4_3: {
                         artIndex: 7,
-                        drawAt: { x: 17, y: 9 },
+                        drawAt: { x: 17, y: 12 },
                     },
                     p4_4: {
                         artIndex: 7,
-                        drawAt: { x: 22, y: 9 },
+                        drawAt: { x: 22, y: 12 },
                     },
                     p4_5: {
                         artIndex: 7,
-                        drawAt: { x: 26, y: 9 },
+                        drawAt: { x: 26, y: 12 },
                     },
                     p4_6: {
                         artIndex: 7,
-                        drawAt: { x: 30, y: 9 },
+                        drawAt: { x: 30, y: 12 },
                     },
                     p4_7: {
                         artIndex: 7,
-                        drawAt: { x: 35, y: 9 },
+                        drawAt: { x: 35, y: 12 },
                     },
                     p4_8: {
                         artIndex: 7,
-                        drawAt: { x: 40, y: 9 },
+                        drawAt: { x: 40, y: 12 },
                     },
                     p5_0: {
                         artIndex: 8,
-                        drawAt: { x: 14, y: 10 },
+                        drawAt: { x: 14, y: 13 },
                     },
                     p5_1: {
                         artIndex: 8,
-                        drawAt: { x: 16, y: 10 },
+                        drawAt: { x: 16, y: 13 },
                     },
                     p5_2: {
                         artIndex: 8,
-                        drawAt: { x: 18, y: 10 },
+                        drawAt: { x: 18, y: 13 },
                     },
                     p5_3: {
                         artIndex: 8,
-                        drawAt: { x: 20, y: 10 },
+                        drawAt: { x: 20, y: 13 },
                     },
                     p5_4: {
                         artIndex: 8,
-                        drawAt: { x: 22, y: 10 },
+                        drawAt: { x: 22, y: 13 },
                     },
                     p5_5: {
                         artIndex: 8,
-                        drawAt: { x: 24, y: 10 },
+                        drawAt: { x: 24, y: 13 },
                     },
                     p5_6: {
                         artIndex: 8,
-                        drawAt: { x: 26, y: 10 },
+                        drawAt: { x: 26, y: 13 },
                     },
                     p5_7: {
                         artIndex: 8,
-                        drawAt: { x: 28, y: 10 },
+                        drawAt: { x: 28, y: 13 },
                     },
                     p5_8: {
                         artIndex: 8,
-                        drawAt: { x: 30, y: 10 },
+                        drawAt: { x: 30, y: 13 },
                     },
                     p5_9: {
                         artIndex: 8,
-                        drawAt: { x: 32, y: 10 },
+                        drawAt: { x: 32, y: 13 },
                     },
                     p5_10: {
                         artIndex: 8,
-                        drawAt: { x: 34, y: 10 },
+                        drawAt: { x: 34, y: 13 },
                     },
                 },
                 art: [
@@ -2203,153 +2210,153 @@
                 positions: {
                     p0_0: {
                         artIndex: 0,
-                        drawAt: { x: -19, y: 19 },
+                        drawAt: { x: -19, y: 22 },
                     },
                     p0_2: {
                         artIndex: 0,
-                        drawAt: { x: 48, y: 19 },
+                        drawAt: { x: 48, y: 22 },
                     },
                     p1_0: {
                         artIndex: 0,
-                        drawAt: { x: 0, y: -17 },
+                        drawAt: { x: 0, y: -14 },
                     },
                     p1_1: {
                         artIndex: 0,
-                        drawAt: { x: 14, y: 13 },
+                        drawAt: { x: 14, y: 16 },
                     },
                     p1_2: {
                         artIndex: 0,
-                        drawAt: { x: 45, y: 13 },
+                        drawAt: { x: 45, y: 16 },
                     },
                     p2_0: {
                         artIndex: 1,
-                        drawAt: { x: -8, y: 12 },
+                        drawAt: { x: -8, y: 15 },
                     },
                     p2_1: {
                         artIndex: 1,
-                        drawAt: { x: 4, y: 13 },
+                        drawAt: { x: 4, y: 16 },
                     },
                     p2_2: {
                         artIndex: 2,
-                        drawAt: { x: 20, y: 13 },
+                        drawAt: { x: 20, y: 16 },
                     },
                     p2_3: {
                         artIndex: 2,
                         drawOptions: { flippedX: true },
-                        drawAt: { x: 36, y: 13 },
+                        drawAt: { x: 36, y: 16 },
                     },
                     p2_4: {
                         artIndex: 2,
                         drawOptions: { flippedX: true },
-                        drawAt: { x: 46, y: 13 },
+                        drawAt: { x: 46, y: 16 },
                     },
                     p3_0: {
                         artIndex: 3,
-                        drawAt: { x: -3, y: 12 },
+                        drawAt: { x: -3, y: 15 },
                     },
                     p3_1: {
                         artIndex: 3,
-                        drawAt: { x: 2, y: 12 },
+                        drawAt: { x: 2, y: 15 },
                     },
                     p3_2: {
                         artIndex: 3,
-                        drawAt: { x: 13, y: 12 },
+                        drawAt: { x: 13, y: 15 },
                     },
                     p3_3: {
                         artIndex: 3,
-                        drawAt: { x: 23, y: 12 },
+                        drawAt: { x: 23, y: 15 },
                     },
                     p3_4: {
                         artIndex: 3,
-                        drawAt: { x: 33, y: 12 },
+                        drawAt: { x: 33, y: 15 },
                     },
                     p3_5: {
                         artIndex: 3,
-                        drawAt: { x: 39, y: 12 },
+                        drawAt: { x: 39, y: 15 },
                     },
                     p3_6: {
                         artIndex: 3,
-                        drawAt: { x: 46, y: 12 },
+                        drawAt: { x: 46, y: 15 },
                     },
                     p4_0: {
                         artIndex: 4,
-                        drawAt: { x: 6, y: 11 },
+                        drawAt: { x: 6, y: 14 },
                     },
                     p4_1: {
                         artIndex: 4,
-                        drawAt: { x: 11, y: 11 },
+                        drawAt: { x: 11, y: 14 },
                     },
                     p4_2: {
                         artIndex: 4,
-                        drawAt: { x: 16, y: 11 },
+                        drawAt: { x: 16, y: 14 },
                     },
                     p4_3: {
                         artIndex: 4,
-                        drawAt: { x: 21, y: 11 },
+                        drawAt: { x: 21, y: 14 },
                     },
                     p4_4: {
                         artIndex: 4,
-                        drawAt: { x: 24, y: 11 },
+                        drawAt: { x: 24, y: 14 },
                     },
                     p4_5: {
                         artIndex: 4,
-                        drawAt: { x: 28, y: 11 },
+                        drawAt: { x: 28, y: 14 },
                     },
                     p4_6: {
                         artIndex: 4,
-                        drawAt: { x: 33, y: 11 },
+                        drawAt: { x: 33, y: 14 },
                     },
                     p4_7: {
                         artIndex: 4,
-                        drawAt: { x: 38, y: 11 },
+                        drawAt: { x: 38, y: 14 },
                     },
                     p4_8: {
                         artIndex: 4,
-                        drawAt: { x: 43, y: 11 },
+                        drawAt: { x: 43, y: 14 },
                     },
                     p5_0: {
                         artIndex: 5,
-                        drawAt: { x: 14, y: 11 },
+                        drawAt: { x: 14, y: 14 },
                     },
                     p5_1: {
                         artIndex: 5,
-                        drawAt: { x: 16, y: 11 },
+                        drawAt: { x: 16, y: 14 },
                     },
                     p5_2: {
                         artIndex: 5,
-                        drawAt: { x: 18, y: 11 },
+                        drawAt: { x: 18, y: 14 },
                     },
                     p5_3: {
                         artIndex: 5,
-                        drawAt: { x: 20, y: 11 },
+                        drawAt: { x: 20, y: 14 },
                     },
                     p5_4: {
                         artIndex: 5,
-                        drawAt: { x: 22, y: 11 },
+                        drawAt: { x: 22, y: 14 },
                     },
                     p5_5: {
                         artIndex: 5,
-                        drawAt: { x: 24, y: 11 },
+                        drawAt: { x: 24, y: 14 },
                     },
                     p5_6: {
                         artIndex: 5,
-                        drawAt: { x: 26, y: 11 },
+                        drawAt: { x: 26, y: 14 },
                     },
                     p5_7: {
                         artIndex: 5,
-                        drawAt: { x: 28, y: 11 },
+                        drawAt: { x: 28, y: 14 },
                     },
                     p5_8: {
                         artIndex: 5,
-                        drawAt: { x: 30, y: 11 },
+                        drawAt: { x: 30, y: 14 },
                     },
                     p5_9: {
                         artIndex: 5,
-                        drawAt: { x: 32, y: 11 },
+                        drawAt: { x: 32, y: 14 },
                     },
                     p5_10: {
                         artIndex: 5,
-                        drawAt: { x: 34, y: 11 },
+                        drawAt: { x: 34, y: 14 },
                     },
                 },
                 art: [
@@ -2406,151 +2413,151 @@
                 positions: {
                     p0_0: {
                         artIndex: 0,
-                        drawAt: { x: -13, y: 11 },
+                        drawAt: { x: -13, y: 14 },
                     },
                     p0_2: {
                         artIndex: 0,
-                        drawAt: { x: 39, y: 22 },
+                        drawAt: { x: 39, y: 25 },
                     },
                     p1_0: {
                         artIndex: 0,
-                        drawAt: { x: -13, y: 9 },
+                        drawAt: { x: -13, y: 12 },
                     },
                     p1_1: {
                         artIndex: 0,
-                        drawAt: { x: 16, y: 7 },
+                        drawAt: { x: 16, y: 10 },
                     },
                     p1_2: {
                         artIndex: 0,
-                        drawAt: { x: 33, y: 7 },
+                        drawAt: { x: 33, y: 10 },
                     },
                     p2_0: {
                         artIndex: 1,
-                        drawAt: { x: -7, y: 8 },
+                        drawAt: { x: -7, y: 11 },
                     },
                     p2_1: {
                         artIndex: 1,
-                        drawAt: { x: 4, y: 7 },
+                        drawAt: { x: 4, y: 10 },
                     },
                     p2_2: {
                         artIndex: 1,
-                        drawAt: { x: 20, y: 7 },
+                        drawAt: { x: 20, y: 10 },
                     },
                     p2_3: {
                         artIndex: 1,
-                        drawAt: { x: 32, y: 7 },
+                        drawAt: { x: 32, y: 10 },
                     },
                     p2_4: {
                         artIndex: 1,
-                        drawAt: { x: 43, y: 8 },
+                        drawAt: { x: 43, y: 11 },
                     },
                     p3_0: {
                         artIndex: 2,
-                        drawAt: { x: -5, y: 10 },
+                        drawAt: { x: -5, y: 13 },
                     },
                     p3_1: {
                         artIndex: 2,
-                        drawAt: { x: 0, y: 9 },
+                        drawAt: { x: 0, y: 12 },
                     },
                     p3_2: {
                         artIndex: 2,
-                        drawAt: { x: 11, y: 9 },
+                        drawAt: { x: 11, y: 12 },
                     },
                     p3_3: {
                         artIndex: 2,
-                        drawAt: { x: 22, y: 9 },
+                        drawAt: { x: 22, y: 12 },
                     },
                     p3_4: {
                         artIndex: 2,
-                        drawAt: { x: 27, y: 9 },
+                        drawAt: { x: 27, y: 12 },
                     },
                     p3_5: {
                         artIndex: 2,
-                        drawAt: { x: 34, y: 9 },
+                        drawAt: { x: 34, y: 12 },
                     },
                     p3_6: {
                         artIndex: 2,
-                        drawAt: { x: 46, y: 11 },
+                        drawAt: { x: 46, y: 14 },
                     },
                     p4_0: {
                         artIndex: 3,
-                        drawAt: { x: 4, y: 10 },
+                        drawAt: { x: 4, y: 13 },
                     },
                     p4_1: {
                         artIndex: 3,
-                        drawAt: { x: 9, y: 10 },
+                        drawAt: { x: 9, y: 13 },
                     },
                     p4_2: {
                         artIndex: 3,
-                        drawAt: { x: 14, y: 10 },
+                        drawAt: { x: 14, y: 13 },
                     },
                     p4_3: {
                         artIndex: 3,
-                        drawAt: { x: 19, y: 10 },
+                        drawAt: { x: 19, y: 13 },
                     },
                     p4_4: {
                         artIndex: 3,
-                        drawAt: { x: 24, y: 10 },
+                        drawAt: { x: 24, y: 13 },
                     },
                     p4_5: {
                         artIndex: 3,
-                        drawAt: { x: 28, y: 10 },
+                        drawAt: { x: 28, y: 13 },
                     },
                     p4_6: {
                         artIndex: 3,
-                        drawAt: { x: 32, y: 10 },
+                        drawAt: { x: 32, y: 13 },
                     },
                     p4_7: {
                         artIndex: 3,
-                        drawAt: { x: 37, y: 10 },
+                        drawAt: { x: 37, y: 13 },
                     },
                     p4_8: {
                         artIndex: 3,
-                        drawAt: { x: 42, y: 10 },
+                        drawAt: { x: 42, y: 13 },
                     },
                     p5_0: {
                         artIndex: 4,
-                        drawAt: { x: 14, y: 11 },
+                        drawAt: { x: 14, y: 14 },
                     },
                     p5_1: {
                         artIndex: 4,
-                        drawAt: { x: 16, y: 11 },
+                        drawAt: { x: 16, y: 14 },
                     },
                     p5_2: {
                         artIndex: 4,
-                        drawAt: { x: 18, y: 11 },
+                        drawAt: { x: 18, y: 14 },
                     },
                     p5_3: {
                         artIndex: 4,
-                        drawAt: { x: 20, y: 11 },
+                        drawAt: { x: 20, y: 14 },
                     },
                     p5_4: {
                         artIndex: 4,
-                        drawAt: { x: 22, y: 11 },
+                        drawAt: { x: 22, y: 14 },
                     },
                     p5_5: {
                         artIndex: 4,
-                        drawAt: { x: 24, y: 11 },
+                        drawAt: { x: 24, y: 14 },
                     },
                     p5_6: {
                         artIndex: 4,
-                        drawAt: { x: 26, y: 11 },
+                        drawAt: { x: 26, y: 14 },
                     },
                     p5_7: {
                         artIndex: 4,
-                        drawAt: { x: 28, y: 11 },
+                        drawAt: { x: 28, y: 14 },
                     },
                     p5_8: {
                         artIndex: 4,
-                        drawAt: { x: 30, y: 11 },
+                        drawAt: { x: 30, y: 14 },
                     },
                     p5_9: {
                         artIndex: 4,
-                        drawAt: { x: 32, y: 11 },
+                        drawAt: { x: 32, y: 14 },
                     },
                     p5_10: {
                         artIndex: 4,
-                        drawAt: { x: 34, y: 11 },
+                        drawAt: { x: 34, y: 14 },
                     },
                 },
                 art: [
@@ -2615,151 +2622,151 @@
                 positions: {
                     p0_0: {
                         artIndex: 0,
-                        drawAt: { x: -14, y: 12 },
+                        drawAt: { x: -14, y: 15 },
                     },
                     p0_2: {
                         artIndex: 0,
-                        drawAt: { x: 45, y: 10 },
+                        drawAt: { x: 45, y: 13 },
                     },
                     p1_0: {
                         artIndex: 0,
-                        drawAt: { x: -13, y: 9 },
+                        drawAt: { x: -13, y: 12 },
                     },
                     p1_1: {
                         artIndex: 0,
-                        drawAt: { x: 17, y: 9 },
+                        drawAt: { x: 17, y: 12 },
                     },
                     p1_2: {
                         artIndex: 0,
-                        drawAt: { x: 36, y: 9 },
+                        drawAt: { x: 36, y: 12 },
                     },
                     p2_0: {
                         artIndex: 1,
-                        drawAt: { x: -7, y: 11 },
+                        drawAt: { x: -7, y: 14 },
                     },
                     p2_1: {
                         artIndex: 1,
-                        drawAt: { x: 3, y: 10 },
+                        drawAt: { x: 3, y: 13 },
                     },
                     p2_2: {
                         artIndex: 1,
-                        drawAt: { x: 19, y: 10 },
+                        drawAt: { x: 19, y: 13 },
                     },
                     p2_3: {
                         artIndex: 1,
-                        drawAt: { x: 33, y: 10 },
+                        drawAt: { x: 33, y: 13 },
                     },
                     p2_4: {
                         artIndex: 1,
-                        drawAt: { x: 44, y: 11 },
+                        drawAt: { x: 44, y: 14 },
                     },
                     p3_0: {
                         artIndex: 2,
-                        drawAt: { x: -3, y: 11 },
+                        drawAt: { x: -3, y: 14 },
                     },
                     p3_1: {
                         artIndex: 2,
-                        drawAt: { x: 1, y: 10 },
+                        drawAt: { x: 1, y: 13 },
                     },
                     p3_2: {
                         artIndex: 2,
-                        drawAt: { x: 11, y: 10 },
+                        drawAt: { x: 11, y: 13 },
                     },
                     p3_3: {
                         artIndex: 2,
-                        drawAt: { x: 22, y: 10 },
+                        drawAt: { x: 22, y: 13 },
                     },
                     p3_4: {
                         artIndex: 2,
-                        drawAt: { x: 28, y: 10 },
+                        drawAt: { x: 28, y: 13 },
                     },
                     p3_5: {
                         artIndex: 2,
-                        drawAt: { x: 35, y: 10 },
+                        drawAt: { x: 35, y: 13 },
                     },
                     p3_6: {
                         artIndex: 2,
-                        drawAt: { x: 46, y: 11 },
+                        drawAt: { x: 46, y: 14 },
                     },
                     p4_0: {
                         artIndex: 3,
-                        drawAt: { x: 3, y: 11 },
+                        drawAt: { x: 3, y: 14 },
                     },
                     p4_1: {
                         artIndex: 3,
-                        drawAt: { x: 8, y: 11 },
+                        drawAt: { x: 8, y: 14 },
                     },
                     p4_2: {
                         artIndex: 3,
-                        drawAt: { x: 13, y: 11 },
+                        drawAt: { x: 13, y: 14 },
                     },
                     p4_3: {
                         artIndex: 3,
-                        drawAt: { x: 18, y: 11 },
+                        drawAt: { x: 18, y: 14 },
                     },
                     p4_4: {
                         artIndex: 3,
-                        drawAt: { x: 23, y: 11 },
+                        drawAt: { x: 23, y: 14 },
                     },
                     p4_5: {
                         artIndex: 3,
-                        drawAt: { x: 27, y: 11 },
+                        drawAt: { x: 27, y: 14 },
                     },
                     p4_6: {
                         artIndex: 3,
-                        drawAt: { x: 31, y: 11 },
+                        drawAt: { x: 31, y: 14 },
                     },
                     p4_7: {
                         artIndex: 3,
-                        drawAt: { x: 36, y: 11 },
+                        drawAt: { x: 36, y: 14 },
                     },
                     p4_8: {
                         artIndex: 3,
-                        drawAt: { x: 41, y: 11 },
+                        drawAt: { x: 41, y: 14 },
                     },
                     p5_0: {
                         artIndex: 4,
-                        drawAt: { x: 14, y: 11 },
+                        drawAt: { x: 14, y: 14 },
                     },
                     p5_1: {
                         artIndex: 4,
-                        drawAt: { x: 16, y: 11 },
+                        drawAt: { x: 16, y: 14 },
                     },
                     p5_2: {
                         artIndex: 4,
-                        drawAt: { x: 18, y: 11 },
+                        drawAt: { x: 18, y: 14 },
                     },
                     p5_3: {
                         artIndex: 4,
-                        drawAt: { x: 20, y: 11 },
+                        drawAt: { x: 20, y: 14 },
                     },
                     p5_4: {
                         artIndex: 4,
-                        drawAt: { x: 22, y: 11 },
+                        drawAt: { x: 22, y: 14 },
                     },
                     p5_5: {
                         artIndex: 4,
-                        drawAt: { x: 24, y: 11 },
+                        drawAt: { x: 24, y: 14 },
                     },
                     p5_6: {
                         artIndex: 4,
-                        drawAt: { x: 26, y: 11 },
+                        drawAt: { x: 26, y: 14 },
                     },
                     p5_7: {
                         artIndex: 4,
-                        drawAt: { x: 28, y: 11 },
+                        drawAt: { x: 28, y: 14 },
                     },
                     p5_8: {
                         artIndex: 4,
-                        drawAt: { x: 30, y: 11 },
+                        drawAt: { x: 30, y: 14 },
                     },
                     p5_9: {
                         artIndex: 4,
-                        drawAt: { x: 32, y: 11 },
+                        drawAt: { x: 32, y: 14 },
                     },
                     p5_10: {
                         artIndex: 4,
-                        drawAt: { x: 34, y: 11 },
+                        drawAt: { x: 34, y: 14 },
                     },
                 },
                 art: [
@@ -2818,151 +2825,151 @@
                 positions: {
                     p0_0: {
                         artIndex: 0,
-                        drawAt: { x: -28, y: 20 },
+                        drawAt: { x: -28, y: 23 },
                     },
                     p0_2: {
                         artIndex: 0,
-                        drawAt: { x: 45, y: 20 },
+                        drawAt: { x: 45, y: 23 },
                     },
                     p1_0: {
                         artIndex: 0,
-                        drawAt: { x: -25, y: 17 },
+                        drawAt: { x: -25, y: 20 },
                     },
                     p1_1: {
                         artIndex: 0,
-                        drawAt: { x: 7, y: 17 },
+                        drawAt: { x: 7, y: 20 },
                     },
                     p1_2: {
                         artIndex: 0,
-                        drawAt: { x: 39, y: 17 },
+                        drawAt: { x: 39, y: 20 },
                     },
                     p2_0: {
                         artIndex: 1,
-                        drawAt: { x: -7, y: 19 },
+                        drawAt: { x: -7, y: 22 },
                     },
                     p2_1: {
                         artIndex: 1,
-                        drawAt: { x: 3, y: 14 },
+                        drawAt: { x: 3, y: 17 },
                     },
                     p2_2: {
                         artIndex: 1,
-                        drawAt: { x: 16, y: 14 },
+                        drawAt: { x: 16, y: 17 },
                     },
                     p2_3: {
                         artIndex: 1,
-                        drawAt: { x: 30, y: 14 },
+                        drawAt: { x: 30, y: 17 },
                     },
                     p2_4: {
                         artIndex: 1,
-                        drawAt: { x: 42, y: 19 },
+                        drawAt: { x: 42, y: 22 },
                     },
                     p3_0: {
                         artIndex: 2,
-                        drawAt: { x: -9, y: 16 },
+                        drawAt: { x: -9, y: 19 },
                     },
                     p3_1: {
                         artIndex: 2,
-                        drawAt: { x: -3, y: 12 },
+                        drawAt: { x: -3, y: 15 },
                     },
                     p3_2: {
                         artIndex: 2,
-                        drawAt: { x: 8, y: 12 },
+                        drawAt: { x: 8, y: 15 },
                     },
                     p3_3: {
                         artIndex: 2,
-                        drawAt: { x: 20, y: 12 },
+                        drawAt: { x: 20, y: 15 },
                     },
                     p3_4: {
                         artIndex: 2,
-                        drawAt: { x: 29, y: 12 },
+                        drawAt: { x: 29, y: 15 },
                     },
                     p3_5: {
                         artIndex: 2,
-                        drawAt: { x: 36, y: 12 },
+                        drawAt: { x: 36, y: 15 },
                     },
                     p3_6: {
                         artIndex: 2,
-                        drawAt: { x: 46, y: 16 },
+                        drawAt: { x: 46, y: 19 },
                     },
                     p4_0: {
                         artIndex: 3,
-                        drawAt: { x: 2, y: 11 },
+                        drawAt: { x: 2, y: 14 },
                     },
                     p4_1: {
                         artIndex: 3,
-                        drawAt: { x: 7, y: 11 },
+                        drawAt: { x: 7, y: 14 },
                     },
                     p4_2: {
                         artIndex: 3,
-                        drawAt: { x: 12, y: 11 },
+                        drawAt: { x: 12, y: 14 },
                     },
                     p4_3: {
                         artIndex: 3,
-                        drawAt: { x: 17, y: 11 },
+                        drawAt: { x: 17, y: 14 },
                     },
                     p4_4: {
                         artIndex: 3,
-                        drawAt: { x: 22, y: 11 },
+                        drawAt: { x: 22, y: 14 },
                     },
                     p4_5: {
                         artIndex: 3,
-                        drawAt: { x: 26, y: 11 },
+                        drawAt: { x: 26, y: 14 },
                     },
                     p4_6: {
                         artIndex: 3,
-                        drawAt: { x: 30, y: 11 },
+                        drawAt: { x: 30, y: 14 },
                     },
                     p4_7: {
                         artIndex: 3,
-                        drawAt: { x: 35, y: 11 },
+                        drawAt: { x: 35, y: 14 },
                     },
                     p4_8: {
                         artIndex: 3,
-                        drawAt: { x: 40, y: 11 },
+                        drawAt: { x: 40, y: 14 },
                     },
                     p5_0: {
                         artIndex: 4,
-                        drawAt: { x: 14, y: 11 },
+                        drawAt: { x: 14, y: 14 },
                     },
                     p5_1: {
                         artIndex: 4,
-                        drawAt: { x: 16, y: 11 },
+                        drawAt: { x: 16, y: 14 },
                     },
                     p5_2: {
                         artIndex: 4,
-                        drawAt: { x: 18, y: 11 },
+                        drawAt: { x: 18, y: 14 },
                     },
                     p5_3: {
                         artIndex: 4,
-                        drawAt: { x: 20, y: 11 },
+                        drawAt: { x: 20, y: 14 },
                     },
                     p5_4: {
                         artIndex: 4,
-                        drawAt: { x: 22, y: 11 },
+                        drawAt: { x: 22, y: 14 },
                     },
                     p5_5: {
                         artIndex: 4,
-                        drawAt: { x: 24, y: 11 },
+                        drawAt: { x: 24, y: 14 },
                     },
                     p5_6: {
                         artIndex: 4,
-                        drawAt: { x: 26, y: 11 },
+                        drawAt: { x: 26, y: 14 },
                     },
                     p5_7: {
                         artIndex: 4,
-                        drawAt: { x: 28, y: 11 },
+                        drawAt: { x: 28, y: 14 },
                     },
                     p5_8: {
                         artIndex: 4,
-                        drawAt: { x: 30, y: 11 },
+                        drawAt: { x: 30, y: 14 },
                     },
                     p5_9: {
                         artIndex: 4,
-                        drawAt: { x: 32, y: 11 },
+                        drawAt: { x: 32, y: 14 },
                     },
                     p5_10: {
                         artIndex: 4,
-                        drawAt: { x: 34, y: 11 },
+                        drawAt: { x: 34, y: 14 },
                     },
                 },
                 art: [
@@ -3012,151 +3019,151 @@
                 positions: {
                     p0_0: {
                         artIndex: 0,
-                        drawAt: { x: -28, y: 20 },
+                        drawAt: { x: -28, y: 23 },
                     },
                     p0_2: {
                         artIndex: 0,
-                        drawAt: { x: 45, y: 20 },
+                        drawAt: { x: 45, y: 23 },
                     },
                     p1_0: {
                         artIndex: 0,
-                        drawAt: { x: -25, y: 17 },
+                        drawAt: { x: -25, y: 20 },
                     },
                     p1_1: {
                         artIndex: 0,
-                        drawAt: { x: 7, y: 17 },
+                        drawAt: { x: 7, y: 20 },
                     },
                     p1_2: {
                         artIndex: 0,
-                        drawAt: { x: 39, y: 17 },
+                        drawAt: { x: 39, y: 20 },
                     },
                     p2_0: {
                         artIndex: 1,
-                        drawAt: { x: -7, y: 19 },
+                        drawAt: { x: -7, y: 22 },
                     },
                     p2_1: {
                         artIndex: 1,
-                        drawAt: { x: 3, y: 14 },
+                        drawAt: { x: 3, y: 17 },
                     },
                     p2_2: {
                         artIndex: 1,
-                        drawAt: { x: 16, y: 14 },
+                        drawAt: { x: 16, y: 17 },
                     },
                     p2_3: {
                         artIndex: 1,
-                        drawAt: { x: 30, y: 14 },
+                        drawAt: { x: 30, y: 17 },
                     },
                     p2_4: {
                         artIndex: 1,
-                        drawAt: { x: 42, y: 19 },
+                        drawAt: { x: 42, y: 22 },
                     },
                     p3_0: {
                         artIndex: 2,
-                        drawAt: { x: -9, y: 16 },
+                        drawAt: { x: -9, y: 19 },
                     },
                     p3_1: {
                         artIndex: 2,
-                        drawAt: { x: -3, y: 12 },
+                        drawAt: { x: -3, y: 15 },
                     },
                     p3_2: {
                         artIndex: 2,
-                        drawAt: { x: 8, y: 12 },
+                        drawAt: { x: 8, y: 15 },
                     },
                     p3_3: {
                         artIndex: 2,
-                        drawAt: { x: 20, y: 12 },
+                        drawAt: { x: 20, y: 15 },
                     },
                     p3_4: {
                         artIndex: 2,
-                        drawAt: { x: 29, y: 12 },
+                        drawAt: { x: 29, y: 15 },
                     },
                     p3_5: {
                         artIndex: 2,
-                        drawAt: { x: 36, y: 12 },
+                        drawAt: { x: 36, y: 15 },
                     },
                     p3_6: {
                         artIndex: 2,
-                        drawAt: { x: 46, y: 16 },
+                        drawAt: { x: 46, y: 19 },
                     },
                     p4_0: {
                         artIndex: 3,
-                        drawAt: { x: 2, y: 11 },
+                        drawAt: { x: 2, y: 14 },
                     },
                     p4_1: {
                         artIndex: 3,
-                        drawAt: { x: 7, y: 11 },
+                        drawAt: { x: 7, y: 14 },
                     },
                     p4_2: {
                         artIndex: 3,
-                        drawAt: { x: 12, y: 11 },
+                        drawAt: { x: 12, y: 14 },
                     },
                     p4_3: {
                         artIndex: 3,
-                        drawAt: { x: 17, y: 11 },
+                        drawAt: { x: 17, y: 14 },
                     },
                     p4_4: {
                         artIndex: 3,
-                        drawAt: { x: 22, y: 11 },
+                        drawAt: { x: 22, y: 14 },
                     },
                     p4_5: {
                         artIndex: 3,
-                        drawAt: { x: 26, y: 11 },
+                        drawAt: { x: 26, y: 14 },
                     },
                     p4_6: {
                         artIndex: 3,
-                        drawAt: { x: 30, y: 11 },
+                        drawAt: { x: 30, y: 14 },
                     },
                     p4_7: {
                         artIndex: 3,
-                        drawAt: { x: 35, y: 11 },
+                        drawAt: { x: 35, y: 14 },
                     },
                     p4_8: {
                         artIndex: 3,
-                        drawAt: { x: 40, y: 11 },
+                        drawAt: { x: 40, y: 14 },
                     },
                     p5_0: {
                         artIndex: 4,
-                        drawAt: { x: 14, y: 11 },
+                        drawAt: { x: 14, y: 14 },
                     },
                     p5_1: {
                         artIndex: 4,
-                        drawAt: { x: 16, y: 11 },
+                        drawAt: { x: 16, y: 14 },
                     },
                     p5_2: {
                         artIndex: 4,
-                        drawAt: { x: 18, y: 11 },
+                        drawAt: { x: 18, y: 14 },
                     },
                     p5_3: {
                         artIndex: 4,
-                        drawAt: { x: 20, y: 11 },
+                        drawAt: { x: 20, y: 14 },
                     },
                     p5_4: {
                         artIndex: 4,
-                        drawAt: { x: 22, y: 11 },
+                        drawAt: { x: 22, y: 14 },
                     },
                     p5_5: {
                         artIndex: 4,
-                        drawAt: { x: 24, y: 11 },
+                        drawAt: { x: 24, y: 14 },
                     },
                     p5_6: {
                         artIndex: 4,
-                        drawAt: { x: 26, y: 11 },
+                        drawAt: { x: 26, y: 14 },
                     },
                     p5_7: {
                         artIndex: 4,
-                        drawAt: { x: 28, y: 11 },
+                        drawAt: { x: 28, y: 14 },
                     },
                     p5_8: {
                         artIndex: 4,
-                        drawAt: { x: 30, y: 11 },
+                        drawAt: { x: 30, y: 14 },
                     },
                     p5_9: {
                         artIndex: 4,
-                        drawAt: { x: 32, y: 11 },
+                        drawAt: { x: 32, y: 14 },
                     },
                     p5_10: {
                         artIndex: 4,
-                        drawAt: { x: 34, y: 11 },
+                        drawAt: { x: 34, y: 14 },
                     },
                 },
                 art: [
@@ -3205,7 +3212,7 @@
 
         const enemyArt = {
             snailSentinel: {
-                drawAt: { x: 19, y: 18 },
+                drawAt: { x: 19, y: 21 },
                 data: `
                        ___   |_|
                       /   \\_/@ @
@@ -3213,7 +3220,7 @@
                 `,
             },
             stupidDog: {
-                drawAt: { x: 22, y: 10 },
+                drawAt: { x: 22, y: 13 },
                 data: `
                     /\\__/\\
                     |@  @|
@@ -3222,7 +3229,7 @@
                 `,
             },
             keeperOfTheToiletBowl: {
-                drawAt: { x: 13, y: 12 },
+                drawAt: { x: 13, y: 15 },
                 data: `
                       _______
                      |       |
@@ -3235,7 +3242,7 @@
                 `,
             },
             mysteriousScooter: {
-                drawAt: { x: 15, y: 14 },
+                drawAt: { x: 15, y: 17 },
                 data: `
                            [~~]=====[~~]
                                 ||
@@ -3246,7 +3253,7 @@
                 `,
             },
             badassFlamingSkeleton: {
-                drawAt: { x: 10, y: 8 },
+                drawAt: { x: 10, y: 11 },
                 data: `
                           |\\ |\\ |\\ |\\ |\\ /| /|
                               _______         /|
@@ -3262,7 +3269,7 @@
                 `,
             },
             wangRat: {
-                drawAt: { x: 11, y: 15 },
+                drawAt: { x: 11, y: 18 },
                 data: `
                        ______
                     (|/      \\|)
@@ -3273,7 +3280,7 @@
                 `,
             },
             fridgeOfForgottenLeftovers: {
-                drawAt: { x: 17, y: 10 },
+                drawAt: { x: 17, y: 13 },
                 data: `
                          ___.---+.
                     .--''       | '.
@@ -3288,7 +3295,7 @@
                 `,
             },
             lughead: {
-                drawAt: { x: 19, y: 12 },
+                drawAt: { x: 19, y: 15 },
                 data: `
                         .--.
                         |oO|
@@ -3301,7 +3308,7 @@
                 `,
             },
             pissedOffPoultry: {
-                drawAt: { x: 17, y: 13 },
+                drawAt: { x: 17, y: 16 },
                 data: `
                     .        .--.
                     |\\      .-:;
@@ -3314,7 +3321,7 @@
                 `,
             },
             krampusElf: {
-                drawAt: { x: 20, y: 13 },
+                drawAt: { x: 20, y: 16 },
                 data: `
                          *
                         / \\
@@ -3327,7 +3334,7 @@
                 `,
             },
             mimic: {
-                drawAt: { x: 5, y: 11 },
+                drawAt: { x: 5, y: 14 },
                 data: `
                      ______________
                     /    \\      /  \\
@@ -3343,7 +3350,7 @@
 
         const sceneRenderer = {
             displayWidth: 50,
-            displayHeight: 22,
+            displayHeight: 28,
             viewDepth: 5,
 
             render: (x, y, direction) => {


### PR DESCRIPTION
After setting a fixed font in https://github.com/packardbell95/tardquest/pull/53, the side walls were truncated. This PR extends the display to occupy 6 more characters in height and adjusts the side wall art to match. So now the walls no longer appear truncated

| <img width="300" src="https://github.com/user-attachments/assets/95af380c-d78b-47e2-bf2e-f265e72bd20d"> | <img width="300" src="https://github.com/user-attachments/assets/b0de7f80-f7d8-47cc-81c1-13d8dc9b28cc"> |
| --- | --- |
| **Before:** Side walls appear truncated | **After:** Walls are no longer cut off |

Fixes https://github.com/packardbell95/tardquest/issues/54