### PR TITLE
New dialogue system + localstorage settings

### DIFF
--- a/src/game.htm
+++ b/src/game.htm
@@ -449,18 +449,18 @@
         #inputBox input {
             color: white;
             font-size: 13px;
-            width: 600px;
+            width: 672px;
             height: 2px;
             z-index: 9;
             background-color: #000;
-            border: 3px dotted #A23AB4;
+            border: 2px solid #ffffff;
             padding: 10px;
             font-size: 16px;
             border-radius: 0px;
             text-align: left;
             position: absolute;
-            top: 125px;
-            left: 58px;
+            top: 117px;
+            left: 28px;
             outline: none;
         }
 
@@ -6577,6 +6577,13 @@
                 hp: 13,
                 attack: [2, 5],
                 bitcoins: 4,
+                talkSlots: [
+                    ["Sss...", "Hrk!", "Glorp", "Snail"],
+                    ["you", "I", "we", "that guy", "snail"],
+                    ["am", "is", "are", "was", "snail", "violated"],
+                    ["slimy", "slow", "fast", "hungry", "snail", "the law"],
+                    ["?", "!", "!!!", "?!", "...", ".",]
+                ]  
             },
             {
                 id: "stupidDog",
@@ -6626,6 +6633,12 @@
                 hp: 28,
                 attack: [8, 13],
                 bitcoins: 4,
+                talkSlots: [
+                    ["Ugh", "LUG", "Arrgh", "UNG", "Borf", "AHHHHHHH", "Bunginga"],
+                    ["smash", "eat", "touch", "rip","friend", "rock", "dance", "pull teeth", "over there"],
+                    ["now", "later", "soon", "maybe", "never", "happy", "punch", "kill", "death"],
+                    ["?", "!", "!!!", "?!", "...", ".",]
+                ]
             },
             {
                 id: "pissedOffPoultry",
@@ -7200,6 +7213,7 @@
         };
 
         let musicEnabled = true;
+        let eatRatAnimationEnabled = true;
 
         function generateMap() {
             setExitPosition();
@@ -7256,6 +7270,21 @@
             spawnHealingTiles();
             spawnCrackedFloors();
         }
+
+        function loadSettings() {
+            const music = localStorage.getItem("musicEnabled");
+            if (music !== null) musicEnabled = music === "true";
+            const eatRat = localStorage.getItem("eatRatAnimationEnabled");
+            if (eatRat !== null) eatRatAnimationEnabled = eatRat === "true";
+        }
+
+        // Save settings to localStorage
+        function saveSettings() {
+            localStorage.setItem("musicEnabled", musicEnabled);
+            localStorage.setItem("eatRatAnimationEnabled", eatRatAnimationEnabled);
+        }
+
+        loadSettings();
 
         function placeWelcomeBanner() {
             if (MAP[player.y - 1][player.x]?.type === 'floor') {
@@ -7526,8 +7555,8 @@
                 .slice()
                 .reverse()
                 .map((msg, i) => {
-                    const lightness = 100 - (i * 15); // Fade effect
-                    const color = `hsl(0, 0%, ${Math.max(lightness, 50)}%)`; // Prevent it from getting too dark
+                    const lightness = 100 - (i * 4); // Fade effect
+                    const color = `hsl(0, 0%, ${Math.max(lightness, 60)}%)`;
                     return `<div style="color: ${color};">${msg}</div>`;
                 })
                 .join("");
@@ -8155,8 +8184,6 @@
             }, 10);
         }
 
-
-
         document.getElementById("persuadeInput").addEventListener("keydown", e => {
             if (e.key === "Enter") {
                 const message = e.target.value;
@@ -8180,20 +8207,31 @@
 
                     if (party.length > 0) {
                         const responder = party[Math.floor(Math.random() * party.length)];
-                        const responses = [
-                            "--you pull out your translator-- 'Wow! Please shut the fuck up.'",
-                            "--you pull out your translator-- 'Just so you know, we're not even...'",
-                            "--you pull out your translator-- 'You can't be fucking serious...'",
-                            "--you pull out your translator-- 'I've come for your pickleeee...'",
-                            "--you pull out your translator-- 'Hey that's cool and all, but have you ever played SpongeBob SquarePants: Revenge of the Flying Dutchman on the Sony PlayStation 2?",
-                            "--they're too busy playing Burnout Revenge on the PS2--",
-                            "--they're too busy sexting your mom--",
-                            "--they pick their own nose, and then they pick YOUR nose...--",
-                            "--you notice them scratching their nuts whilst ignoring your interjection--",
-                        ];
 
-                        const reply = responses[Math.floor(Math.random() * responses.length)];
-                        updateBattleLog(`${responder.name}: ${reply}`);
+                        const enemyDef = enemies.find(e => e.name === responder.name);
+
+                        // Allow use of enemy specific talk slots
+                        let talkSlots = enemyDef?.talkSlots;
+                        if (!Array.isArray(talkSlots) || talkSlots.length === 0) {
+                            // Fallback to default talk slots if an enemy does not have a unique set
+                            talkSlots = [
+                                ["You", "I", "What", "Hey", "Listen", "They", "He", "She"],
+                                ["are", "can't", "should", "will", "must", "here", "a need to", "need", "needed"],
+                                ["a pot roast", "many pot roasts", "a total dumbass", "gay", "my friend", "a sandwich", "obey"],
+                                ["?", "!", "!!!", "?!", "...", ".",]
+                            ];
+                        }
+
+                        // Sentence assembly - also removes the space before the punctioation slot
+                        const chosen = talkSlots.map(slot => slot[Math.floor(Math.random() * slot.length)]);
+                        const sentence =
+                            chosen.length > 1
+                                ? chosen.slice(0, -1).join(" ") + chosen[chosen.length - 1]
+                                : chosen[0];
+
+                        updateBattleLog(
+                            `<span class="friendly">${responder.name}:</span> <span class="player">--you pull out your translator--</span> "${sentence}"`
+                        );
                     }
 
                     render();
@@ -9093,6 +9131,15 @@
                                 : "Turn on the in game music",
                         },
                         {
+                            id: "toggleEatRatAnimation",
+                            displayText: eatRatAnimationEnabled
+                                ? "Disable level up animation"
+                                : "Enable level up animation",
+                            description: eatRatAnimationEnabled
+                                ? "Disable rat consumption animation on level up"
+                                : "Enable rat consumption animation on level up",
+                        },
+                        {
                             id: "resetGame",
                             displayText: "Reset the game",
                             description:
@@ -9111,7 +9158,7 @@
                         switch (selectedOptionId) {
                             case "toggleMusic":
                                 musicEnabled = !musicEnabled;
-
+                                saveSettings();
                                 stopAllMusic();
                                 if (musicEnabled) {
                                     player.inCombat
@@ -9121,6 +9168,10 @@
                                             : playRandomExplorationMusic()
                                         );
                                 }
+                                break;
+                            case "toggleEatRatAnimation":
+                                eatRatAnimationEnabled = !eatRatAnimationEnabled;
+                                saveSettings();
                                 break;
                             case "resetGame":
                             case "returnToTitleScreen":
@@ -9954,7 +10005,7 @@
                             }
                             menu.close();
                             render();
-                            animEatRat();
+                            if (eatRatAnimationEnabled) animEatRat();
                         } else if (selectedOptionId === "reset") {
                             if (isLevelUpAllocation) {
                                 player.maxHp = levelUpAllocatedStats.base.maxHp;

--- a/src/game.htm
+++ b/src/game.htm
@@ -6578,10 +6578,10 @@
                 attack: [2, 5],
                 bitcoins: 4,
                 talkSlots: [
-                    ["Sss...", "Hrk!", "Glorp", "Snail"],
-                    ["you", "I", "we", "that guy", "snail"],
-                    ["am", "is", "are", "was", "snail", "violated"],
-                    ["slimy", "slow", "fast", "hungry", "snail", "the law"],
+                    ["Sss...", "Hrk!", "Glorp", "Snail", "Halt!", "Beware"],
+                    ["you", "I", "we", "that guy", "snail", "he", "she", "it", "has"],
+                    ["am", "is", "are", "was", "snail", "violated", "trespassing", "guarding"],
+                    ["slimy", "slow", "fast", "hungry", "snail", "the law", "Judge Joody", "my antennae", "the shell"],
                     ["?", "!", "!!!", "?!", "...", ".",]
                 ]  
             },
@@ -6635,8 +6635,8 @@
                 bitcoins: 4,
                 talkSlots: [
                     ["Ugh", "LUG", "Arrgh", "UNG", "Borf", "AHHHHHHH", "Bunginga"],
-                    ["smash", "eat", "touch", "rip","friend", "rock", "dance", "pull teeth", "over there"],
-                    ["now", "later", "soon", "maybe", "never", "happy", "punch", "kill", "death"],
+                    ["smash", "eat", "touch", "rip", "grab", "friend", "befriend", "love", "rock", "dance", "pull teeth", "over there"],
+                    ["now", "later", "soon", "maybe", "never", "happy", "punch", "kill", "death", "Phillips CD-i", "Bubsy 3D"],
                     ["?", "!", "!!!", "?!", "...", ".",]
                 ]
             },
@@ -8218,10 +8218,10 @@
                         if (!Array.isArray(talkSlots) || talkSlots.length === 0) {
                             // Fallback to default talk slots if an enemy does not have a unique set
                             talkSlots = [
-                                ["You", "I", "What", "Hey", "Listen", "They", "He", "She"],
-                                ["are", "can't", "should", "will", "must", "here", "a need to", "need", "needs", "needed"],
-                                ["go", "find a", "smack a", "kill the", "eat a", "snack on a", "pick my", "pick your"],
-                                ["pot roast", "many pot roasts", "total dumbass", "gay", "friend", "sandwich", "obey", "nose", "orbital laser", "Burnout Revenge on the PS2"],
+                                ["You", "I", "What", "Hey", "Listen here, you", "They", "He", "She"],
+                                ["are", "can't", "should", "will", "must", "need to", "need", "needs", "needed"],
+                                ["go", "find a", "smack a", "kill the", "eat a", "snack on a", "pick my", "pick your", "obey my", "obey your"],
+                                ["pot roast", "many pot roasts", "total dumbass", "gay", "friend", "sandwich", "nose", "orbital laser", "Burnout Revenge on the PS2", "one big dandruff"],
                                 ["?", "!", "!!!", "?!", "...", ".",]
                             ];
                         }

--- a/src/game.htm
+++ b/src/game.htm
@@ -7213,6 +7213,7 @@
         };
 
         let musicEnabled = true;
+        let sfxEnabled = true;
         let eatRatAnimationEnabled = true;
 
         function generateMap() {
@@ -7276,12 +7277,14 @@
             if (music !== null) musicEnabled = music === "true";
             const eatRat = localStorage.getItem("eatRatAnimationEnabled");
             if (eatRat !== null) eatRatAnimationEnabled = eatRat === "true";
+            const sfx = localStorage.getItem("sfxEnabled");
+            if (sfx !== null) sfxEnabled = sfx === "true";
         }
 
-        // Save settings to localStorage
         function saveSettings() {
             localStorage.setItem("musicEnabled", musicEnabled);
             localStorage.setItem("eatRatAnimationEnabled", eatRatAnimationEnabled);
+            localStorage.setItem("sfxEnabled", sfxEnabled);
         }
 
         loadSettings();
@@ -7563,11 +7566,11 @@
         }
 
         function playSFX(name) {
+            if (!sfxEnabled) return;
             if (!sfx[name]) {
                 console.error("SFX not found", { name });
                 return;
             }
-
             sfx[name].currentTime = 0;
             sfx[name].play();
         }
@@ -9132,6 +9135,13 @@
                                 : "Turn on the in game music",
                         },
                         {
+                            id: "toggleSFX",
+                            displayText: sfxEnabled ? "Disable SFX" : "Enable SFX",
+                            description: sfxEnabled
+                                ? "Disable sound effects"
+                                : "Enable sound effects",
+                        },
+                        {
                             id: "toggleEatRatAnimation",
                             displayText: eatRatAnimationEnabled
                                 ? "Disable level up animation"
@@ -9169,6 +9179,10 @@
                                             : playRandomExplorationMusic()
                                         );
                                 }
+                                break;
+                            case "toggleSFX":
+                                sfxEnabled = !sfxEnabled;
+                                saveSettings();
                                 break;
                             case "toggleEatRatAnimation":
                                 eatRatAnimationEnabled = !eatRatAnimationEnabled;

--- a/src/game.htm
+++ b/src/game.htm
@@ -8216,8 +8216,9 @@
                             // Fallback to default talk slots if an enemy does not have a unique set
                             talkSlots = [
                                 ["You", "I", "What", "Hey", "Listen", "They", "He", "She"],
-                                ["are", "can't", "should", "will", "must", "here", "a need to", "need", "needed"],
-                                ["a pot roast", "many pot roasts", "a total dumbass", "gay", "my friend", "a sandwich", "obey"],
+                                ["are", "can't", "should", "will", "must", "here", "a need to", "need", "needs", "needed"],
+                                ["go", "find a", "smack a", "kill the", "eat a", "snack on a", "pick my", "pick your"],
+                                ["pot roast", "many pot roasts", "total dumbass", "gay", "friend", "sandwich", "obey", "nose", "orbital laser", "Burnout Revenge on the PS2"],
                                 ["?", "!", "!!!", "?!", "...", ".",]
                             ];
                         }
@@ -8258,7 +8259,7 @@
                             healedThisBattle: false
                         };
                         party.push(newAlly);
-                        updateBattleLog(`<span class="PRS">${currentEnemy.name}</span> is now following your trail of sweat.`);
+                        updateBattleLog(`<span class="friendly">${currentEnemy.name}</span> is now following your trail of sweat.`);
                     } else {
                         updateBattleLog(`<span class="action">${currentEnemy.name}</span> was <span class="friendly">spared</span> and went back home...`);
                     }


### PR DESCRIPTION
This includes the new dialogue system we discussed where when using the TALK function while you have party members, instead of pulling a random preset static message, it will instead pull random words from word/phrase pools and insert them into wordslots to create a sentence. Now you will have brilliantly nonsensical and braindead randomized dialogue such as the following:

![Screenshot 2025-06-28 170659](https://github.com/user-attachments/assets/17f20ece-4513-4aa0-836b-57e789cbada0)
![Screenshot 2025-06-28 181621](https://github.com/user-attachments/assets/cd86f1c0-a5ba-47cd-8b39-e9ca766b1056)

Under the enemies object, you can easily define a specific set of word/phrase pools for specific enemies. Any that don't have their own unique set will use the default fallback set instead. I adjusted the battlelog text gradient as well (which is _not_ demonstrated in the first screenshot).

I've once again changed how the textbox is presented as well.

![Screenshot 2025-06-28 183713](https://github.com/user-attachments/assets/d2dedc1d-0bcc-4463-ab97-78a0d20c95c1)

I've also added a toggle for level up animations via the settings menu, and implemented localstorage persistence for that and the music toggle.

Issues #76 and #72 will be left unresolved for now, because I'm sure we'll still want to add more settings to add localstorage to and we may still want to add TTS playback to the party dialogue in the future.