### PR TITLE
Animated menu + NPC portraits

### DIFF
--- a/src/game.html
+++ b/src/game.html
@@ -524,6 +524,24 @@
             color: #f00;
         }
 
+        #portraitArtOverlay.portrait-art {
+            position: absolute;
+            left: 31px;
+            top: 140px;
+            width: 217px;
+            height: 166px;
+            pointer-events: none;
+            z-index: 10;
+            font-family: "DejaVuSansMono", monospace;
+            font-size: 5px;
+            line-height: 1;
+            white-space: pre;
+            background-color: #000000;
+        }
+        #portraitArtOverlay.hidden {
+            display: none;
+        }
+
         .hidden {
             display: none;
         }
@@ -929,6 +947,7 @@ A Javascript game by <a href="https://xxthemilkman69xx.neocities.org/" target="_
         <div id="sidePanel">
             <div id="battleLog"></div>
             <div id="minimap"></div>
+            <pre id="portraitArtOverlay" class="portrait-art hidden"></pre>
             <div id="inputBox">
                 <input type="text" id="persuadeInput" placeholder="Say your piece...">
             </div>
@@ -7391,6 +7410,8 @@ A Javascript game by <a href="https://xxthemilkman69xx.neocities.org/" target="_
         let sfxEnabled = true;
         let skipTitleScreen = false;
         let eatRatAnimationEnabled = true;
+        let inventoryAsciiAnimInterval = null;
+        let inventoryAsciiFrame = 0;
 
         function generateMap() {
             setExitPosition();
@@ -7463,23 +7484,6 @@ A Javascript game by <a href="https://xxthemilkman69xx.neocities.org/" target="_
             localStorage.setItem("eatRatAnimationEnabled", eatRatAnimationEnabled);
             localStorage.setItem("sfxEnabled", sfxEnabled);
             localStorage.setItem("skipTitleScreen", skipTitleScreen);
-        }
-
-        loadSettings();
-
-        function loadSettings() {
-            const music = localStorage.getItem("musicEnabled");
-            if (music !== null) musicEnabled = music === "true";
-            const eatRat = localStorage.getItem("eatRatAnimationEnabled");
-            if (eatRat !== null) eatRatAnimationEnabled = eatRat === "true";
-            const sfx = localStorage.getItem("sfxEnabled");
-            if (sfx !== null) sfxEnabled = sfx === "true";
-        }
-
-        function saveSettings() {
-            localStorage.setItem("musicEnabled", musicEnabled);
-            localStorage.setItem("eatRatAnimationEnabled", eatRatAnimationEnabled);
-            localStorage.setItem("sfxEnabled", sfxEnabled);
         }
 
         loadSettings();
@@ -7583,7 +7587,119 @@ A Javascript game by <a href="https://xxthemilkman69xx.neocities.org/" target="_
             }
         }
 
-        function getRandomMerchantItem() {
+// Menu ASCII Portraits
+        // Inventory portrait
+        function showInventoryAsciiArt() {
+            const overlay = document.getElementById('portraitArtOverlay');
+            if (!overlay) return;
+            clearTimeout(inventoryAsciiAnimInterval);
+            inventoryAsciiFrame = 0;
+            overlay.classList.remove('hidden');
+
+            function drawFrame() {
+                overlay.innerText = portraitFramesInventory[inventoryAsciiFrame];
+                inventoryAsciiFrame++;
+                if (inventoryAsciiFrame < portraitFramesInventory.length) {
+                    inventoryAsciiAnimInterval = setTimeout(drawFrame, 110);
+                } else {
+                    inventoryAsciiAnimInterval = null;
+                }
+            }
+            drawFrame();
+        }
+
+        function hideInventoryAsciiArtAndRestoreMinimap() {
+            clearTimeout(inventoryAsciiAnimInterval);
+            inventoryAsciiAnimInterval = null;
+            const overlay = document.getElementById('portraitArtOverlay');
+            if (overlay) overlay.classList.add('hidden');
+            drawMinimap();
+        }
+
+        // Gambler portrait
+        function showGamblerAsciiArt() {
+            const overlay = document.getElementById('portraitArtOverlay');
+            if (!overlay) return;
+            clearTimeout(inventoryAsciiAnimInterval);
+            inventoryAsciiFrame = 0;
+            overlay.classList.remove('hidden');
+
+            function drawFrame() {
+                overlay.innerText = portraitFramesGambler[inventoryAsciiFrame];
+                inventoryAsciiFrame++;
+                if (inventoryAsciiFrame < portraitFramesGambler.length) {
+                    inventoryAsciiAnimInterval = setTimeout(drawFrame, 180);
+                } else {
+                    inventoryAsciiFrame = 0;
+                    inventoryAsciiAnimInterval = setTimeout(drawFrame, 180);
+                }
+            }
+            drawFrame();
+        }
+
+        // Merchant portrait
+        function showMerchantAsciiArt() {
+            const overlay = document.getElementById('portraitArtOverlay');
+            if (!overlay) return;
+            clearTimeout(inventoryAsciiAnimInterval);
+            inventoryAsciiFrame = 0;
+            overlay.classList.remove('hidden');
+
+            function drawFrame() {
+                overlay.innerText = portraitFramesMerchant[inventoryAsciiFrame];
+                inventoryAsciiFrame++;
+                if (inventoryAsciiFrame < portraitFramesMerchant.length) {
+                    inventoryAsciiAnimInterval = setTimeout(drawFrame, 250);
+                } else {
+                    inventoryAsciiFrame = 0; // Loop
+                    inventoryAsciiAnimInterval = setTimeout(drawFrame, 250);
+                }
+            }
+            drawFrame();
+        }
+
+        // Chest portrait
+        function showChestAsciiArt() {
+            const overlay = document.getElementById('portraitArtOverlay');
+            if (!overlay) return;
+            clearTimeout(inventoryAsciiAnimInterval);
+            inventoryAsciiFrame = 0;
+            overlay.classList.remove('hidden');
+
+            function drawFrame() {
+                overlay.innerText = portraitFramesChest[inventoryAsciiFrame];
+                inventoryAsciiFrame++;
+                if (inventoryAsciiFrame < portraitFramesChest.length) {
+                    inventoryAsciiAnimInterval = setTimeout(drawFrame, 400);
+                } else {
+                    inventoryAsciiAnimInterval = null;
+                }
+            }
+            drawFrame();
+        }
+
+        // Settings portrait
+        function showSettingsAsciiArt() {
+            const overlay = document.getElementById('portraitArtOverlay');
+            if (!overlay) return;
+            clearTimeout(inventoryAsciiAnimInterval);
+            inventoryAsciiFrame = 0;
+            overlay.classList.remove('hidden');
+
+            function drawFrame() {
+                overlay.innerText = portraitFramesSettings[inventoryAsciiFrame];
+                inventoryAsciiFrame++;
+                if (inventoryAsciiFrame < portraitFramesSettings.length) {
+                    inventoryAsciiAnimInterval = setTimeout(drawFrame, 140);
+                } else {
+                    inventoryAsciiFrame = 0; // Loop
+                    inventoryAsciiAnimInterval = setTimeout(drawFrame, 140);
+                }
+            }
+            drawFrame();
+        }
+
+                function getRandomMerchantItem() {
             const availableItems = Object.keys(items).filter(itemId => items[itemId].merchantStockChance > 0);
             return availableItems[Math.floor(Math.random() * availableItems.length)];
         }
@@ -7708,6 +7824,7 @@ A Javascript game by <a href="https://xxthemilkman69xx.neocities.org/" target="_
         }
 
         function drawMinimap() {
+            if (inventoryAsciiAnimInterval) return;
             let out = '';
             for (let y = 0; y < HEIGHT; y++) {
                 for (let x = 0; x < WIDTH; x++) {
@@ -8165,8 +8282,8 @@ A Javascript game by <a href="https://xxthemilkman69xx.neocities.org/" target="_
         }
 
         function getCarryWeightLimit() {
-            // Example: 35 base + 1.3 per END point
-            return 35 + player.endurance * 1.3;
+            // Example: 35 base + 0.4 per END point
+            return 35 + player.endurance * 0.3;
         }
 
         function updateBreathingSFX() {
@@ -9325,6 +9442,12 @@ A Javascript game by <a href="https://xxthemilkman69xx.neocities.org/" target="_
             menus: {
                 gameSettings: {
                     title: "GAME SETTINGS",
+                    onOpen: () => {
+                        showSettingsAsciiArt();
+                    },
+                    onClose: () => {
+                        hideInventoryAsciiArtAndRestoreMinimap();
+                    },
                     getOptions: () => [
                         {
                             id: "_back",
@@ -9367,8 +9490,8 @@ A Javascript game by <a href="https://xxthemilkman69xx.neocities.org/" target="_
                             id: "resetGame",
                             displayText: "Reset the game",
                             description:
-                                "Abandon your current quest and return to " +
-                                "the title screen",
+                                "Abandon your current game and return to the " +
+                                "title screen",
                         },
                     ],
                     select: (selectedOptionId) => {
@@ -9399,6 +9522,7 @@ A Javascript game by <a href="https://xxthemilkman69xx.neocities.org/" target="_
                                 saveSettings();
                                 break;
                             case "resetGame":
+                            case "returnToTitleScreen":
                                 menu.open("resetGameConfirmation");
                                 break;
                         }
@@ -9450,6 +9574,12 @@ A Javascript game by <a href="https://xxthemilkman69xx.neocities.org/" target="_
                     ],
                     select: (selectedOptionId) => {
                         menu.open(selectedOptionId);
+                    },
+                    onOpen: () => {
+                        showInventoryAsciiArt();
+                    },
+                    onClose: () => {
+                        hideInventoryAsciiArtAndRestoreMinimap();
                     },
                 },
                 inventoryItems: {
@@ -9710,9 +9840,11 @@ A Javascript game by <a href="https://xxthemilkman69xx.neocities.org/" target="_
                     title: "MERCHANT",
                     onOpen: () => {
                         merchant.say('Welcome to SlobMart!');
+                        showMerchantAsciiArt();
                     },
                     onClose: () => {
                         merchant.say('Thank you. Come again!');
+                        hideInventoryAsciiArtAndRestoreMinimap();
                     },
                     landingHtml: () => {
                         return player.bitcoins > 0
@@ -10053,6 +10185,7 @@ A Javascript game by <a href="https://xxthemilkman69xx.neocities.org/" target="_
                     title: "GAMBLER",
                     onOpen: () => {
                         gambler.say('Place yer bets!');
+                        showGamblerAsciiArt();
                     },
                     onClose: () => {
                         gambler.isActiveOnFloor = false;
@@ -10060,6 +10193,7 @@ A Javascript game by <a href="https://xxthemilkman69xx.neocities.org/" target="_
                         if (gamblerPosition) {
                             MAP[gamblerPosition.y][gamblerPosition.x] = new MapCell();
                         }
+                        hideInventoryAsciiArtAndRestoreMinimap();
                     },
                     landingHtml: () => {
                         return (
@@ -10090,6 +10224,12 @@ A Javascript game by <a href="https://xxthemilkman69xx.neocities.org/" target="_
                 },
                 chest: {
                     title: "TREASURE CHEST",
+                    onOpen: () => {
+                        showChestAsciiArt();
+                    },
+                    onClose: () => {
+                        hideInventoryAsciiArtAndRestoreMinimap();
+                    },
                     landingHtml: () => {
                         return `\n\n\nYou found a treasure chest! Do you want to open it?`;
                     },
@@ -10583,6 +10723,879 @@ A Javascript game by <a href="https://xxthemilkman69xx.neocities.org/" target="_
         ['█▀▀▀ ', '▀▀▀▄ ', '▀▄▄▀ '], // 5
         ['▄▀▀▀ ', '█▀▀▄ ', '▀▄▄▀ '], // 6
     ];
+
+    const portraitFramesInventory = [
+    `
+                            ██████                        
+                       ██████    ████                     
+                    ████  ██   ███  ██                    
+                    █      █  ██   ███                    
+                    █████       ███                       
+                        ██      █                         
+                         █      █        █                
+                        ██████████████████                
+                         █      █                         
+                        ██      ██                        
+                      ███        █                        
+                    ███  ██       █                       
+                 ████    █        ███                     
+             █████      ██    █     ████                  
+          ████         ██      █       ████               
+       ████           ██       █          █████████       
+    ███             ██         ██                 ██████  
+  ███             ██            █       ███            ██ 
+  █              ██              █         ███████      ██
+ █                               ██               █████  █
+ █                                ██                     █
+ █                                 ██                   ██
+██                                  ██                 ██ 
+██                                   █               ███  
+ █                                                 ███    
+  ██                                             ███      
+   ███                                       █████        
+     ████                                █████            
+        █████████████████████████████████                                                                               
+    `,
+    `
+    
+                   █████████████████                      
+                 ███  ███      ███ ████                   
+                ██      █     ██      ███                 
+                ███           █      ████                 
+                  ██████          ████                    
+                       ██       ███    ███                
+                        ██   ███████████                  
+                         █      █                         
+                        ██      ██                        
+                      ███        █                        
+                    ███           █                       
+                 ████             ███                     
+             █████                  ████                  
+          ████                         ████               
+       ████         ██                    █████████       
+    ███            ██        █                    ██████  
+  ███             ██         ██        ███             ██ 
+  █              █            █          ████           ██
+ █              ██            ██             ████        █
+ █           ████              █                ███      █
+ █        ████                  █                 ██    ██
+██      ███                      ██                █   ██ 
+██     ██                         ██                 ███  
+ █     █                           ██              ███    
+  ██   █                            ██           ███      
+   ███                                       █████        
+     ████                                █████            
+        █████████████████████████████████                 
+    `,
+    `
+
+
+
+
+           █████████████████████                              
+         ███▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒███████                        
+        ██▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒███████                  
+        ██▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒█████              
+         █████▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒███            
+             ███▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒██████            
+               ███▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒█████                 
+                 ██  ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒███                      
+                 ██          ▒▒▒▒▒██████████                  
+             █████                  ████   ███████            
+          ████      █                  ████      ██████       
+       ████        ██                ██   █████████   ████    
+    ███           ██                  ███         ██████ ████ 
+  ███            ██                     ████           ██   ██
+  █            ███             █           ███          ██   █
+ █           ███               █             ███         █    
+ █        ████                 ██              ██        █    
+ █     ████                     █               ██      ██    
+██  ████                        ██               █     ██     
+██ ██                            █               ██  ███      
+ █                               ██                ███        
+  ██                              █              ███          
+   ███                            ██         █████            
+     ████                                █████                
+        █████████████████████████████████                     
+    `,
+    ];
+
+    const portraitFramesGambler = [
+    ` 
+                                      ██       
+              ███                    ██ ███    
+           ████ █ ████████████████████    ████ 
+         ███    ███               ███        █ 
+       ███      ██               ██          ██
+      ██         █                            █
+      █                                       █
+      █                                       █
+      █       ████████         █████████      █
+      █          ██                ██         █
+      █                                      ██
+      █     ███                      ███     █ 
+      █     █ █                      █ █    ██ 
+      ██      █                     ██     ██  
+       █      █                     █    ███   
+       ██     ██                    █   ██     
+        ███    █                    █ ████     
+       █████████                    ███  ██    
+     ███      ██                   ██     ██   
+   ███         █                   █       ██  
+  ██           ██                 ██        █  
+ ██             ██               ██         ██ 
+██       █       ███  █████████ ██           █ 
+█     █  █  █      ████       ███ █          █ 
+█     ██ ██ ██       ████   ████  █ █ █     ██ 
+█     █ █  █ █ █        █████    █ █ ██    ██  
+██    █      ██           █    █ █    █  ███   
+ ████ █      █                  ██    ████ █   
+  █  ██      █                   █████     █   
+  █    ██████                              █   
+    `,
+    `
+                                      ██       
+              ███                    ██ ███    
+           ████ █ ████████████████████    ████ 
+         ███    ███               ███        █ 
+       ███      ██               ██          ██
+      ██         █                            █
+      █                                       █
+      █                                       █
+      █       ████████         █████████      █
+      █          ██                ██         █
+      █                                      ██
+      █     ███                      ███     █ 
+      █     █ █                      █ █    ██ 
+      ██      █                     ██     ██  
+       █      █                     █    ███   
+       ██     ██                    █   ██     
+        ███    █                    █ ████     
+       █████████                    ███  ██    
+     ███      ██                   ██     ██   
+   ███         █                   █       ██  
+  ██           ██                 ██        █  
+ ██             ██               ██         ██ 
+██               ███  █████████  █           █ 
+█                  ████       █████  █       █ 
+█         █          ████   █████ ██ ██     ██ 
+█     █ █ █             █████  █ █  █ █    ██  
+██   █ █ ██ █             █  █ █      █  ███   
+ █████    ██                  ██      ████ █   
+  █  █    █                    █      █    █   
+  █  █████                      ██████     █   
+    `,
+    ` 
+                                      ██       
+              ███                    ██ ███    
+           ████ █ ████████████████████    ████ 
+         ███    ███               ███        █ 
+       ███      ██               ██          ██
+      ██         █                            █
+      █                                       █
+      █                                       █
+      █       ████████         █████████      █
+      █          ██                ██         █
+      █                                      ██
+      █     ███                      ███     █ 
+      █     █ █                      █ █    ██ 
+      ██      █                     ██     ██  
+       █      █                     █    ███   
+       ██     ██                    █   ██     
+        ███    █                    █ ████     
+       █████████                    ███  ██    
+     ███      ██                   ██     ██   
+   ███         █                   █       ██  
+  ██           ██                 ██        █  
+ ██             ██               ██         ██ 
+██       █       ███  █████████ ██           █ 
+█     █  █  █      ████       ███ █          █ 
+█     ██ ██ ██       ████   ████  █ █ █     ██ 
+█     █ █  █ █ █        █████    █ █ ██    ██  
+██    █      ██           █    █ █    █  ███   
+ ████ █      █                  ██    ████ █   
+  █  ██      █                   █████     █   
+  █    ██████                              █   
+    `,
+    `
+                                      ██       
+              ███                    ██ ███    
+           ████ █ ████████████████████    ████ 
+         ███    ███               ███        █ 
+       ███      ██               ██          ██
+      ██         █                            █
+      █                                       █
+      █                                       █
+      █       ████████         █████████      █
+      █          ██                ██         █
+      █                                      ██
+      █     ███                      ███     █ 
+      █     █ █                      █ █    ██ 
+      ██      █                     ██     ██  
+       █      █                     █    ███   
+       ██     ██                    █   ██     
+        ███    █                    █ ████     
+       █████████                    ███  ██    
+     ███      ██                   ██     ██   
+   ███         █                   █       ██  
+  ██           ██                 ██        █  
+ ██             ██               ██         ██ 
+██               ███  █████████  █           █ 
+█                  ████       █████  █       █ 
+█         █          ████   █████ ██ ██     ██ 
+█     █ █ █             █████  █ █  █ █    ██  
+██   █ █ ██ █             █  █ █      █  ███   
+ █████    ██                  ██      ████ █   
+  █  █    █                    █      █    █   
+  █  █████                      ██████     █   
+    `,
+    ` 
+                                      ██       
+              ███                    ██ ███    
+           ████ █ ████████████████████    ████ 
+         ███    ███               ███        █ 
+       ███      ██               ██          ██
+      ██         █                            █
+      █                                       █
+      █                                       █
+      █       ████████         █████████      █
+      █          ██                ██         █
+      █                                      ██
+      █     ███                      ███     █ 
+      █     █ █                      █ █    ██ 
+      ██      █                     ██     ██  
+       █      █                     █    ███   
+       ██     ██                    █   ██     
+        ███    █                    █ ████     
+       █████████                    ███  ██    
+     ███      ██                   ██     ██   
+   ███         █                   █       ██  
+  ██           ██                 ██        █  
+ ██             ██               ██         ██ 
+██       █       ███  █████████ ██           █ 
+█     █  █  █      ████       ███ █          █ 
+█     ██ ██ ██       ████   ████  █ █ █     ██ 
+█     █ █  █ █ █        █████    █ █ ██    ██  
+██    █      ██           █    █ █    █  ███   
+ ████ █      █                  ██    ████ █   
+  █  ██      █                   █████     █   
+  █    ██████                              █   
+    `,
+    `
+                                      ██       
+              ███                    ██ ███    
+           ████ █ ████████████████████    ████ 
+         ███    ███               ███        █ 
+       ███      ██               ██          ██
+      ██         █                            █
+      █                                       █
+      █                                       █
+      █       ████████         █████████      █
+      █          ██                ██         █
+      █                                      ██
+      █     ███                      ███     █ 
+      █     █ █                      █ █    ██ 
+      ██      █                     ██     ██  
+       █      █                     █    ███   
+       ██     ██                    █   ██     
+        ███    █                    █ ████     
+       █████████                    ███  ██    
+     ███      ██                   ██     ██   
+   ███         █                   █       ██  
+  ██           ██                 ██        █  
+ ██             ██               ██         ██ 
+██               ███  █████████  █           █ 
+█                  ████       █████  █       █ 
+█         █          ████   █████ ██ ██     ██ 
+█     █ █ █             █████  █ █  █ █    ██  
+██   █ █ ██ █             █  █ █      █  ███   
+ █████    ██                  ██      ████ █   
+  █  █    █                    █      █    █   
+  █  █████                      ██████     █   
+    `,
+    `
+                                      ██       
+              ███                    ██ ███    
+           ████ █ ████████████████████    ████ 
+         ███    ███               ███        █ 
+       ███      ██               ██          ██
+      ██         █                            █
+      █                                       █
+      █                                       █
+      █       ████████         █████████      █
+      █          ██                ██         █
+      █                                      ██
+      █     ███                      ███     █ 
+      █     █ █                      █ █    ██ 
+      ██      █                     ██     ██  
+       █      █                     █    ███   
+       ██     ██                    █   ██     
+        ███    █                    █ ████     
+       █████████                    ███  ██    
+     ███      ██                   ██     ██   
+   ███         █                   █       ██  
+  ██           ██                 ██        █  
+ ██             ██               ██         ██ 
+██       █       ███  █████████ ██           █ 
+█     █  █  █      ████       ███ █          █ 
+█     ██ ██ ██       ████   ████  █ █ █     ██ 
+█     █ █  █ █ █        █████    █ █ ██    ██  
+██    █      ██           █    █ █    █  ███   
+ ████ █      █                  ██    ████ █   
+  █  ██      █                   █████     █   
+  █    ██████                              █   
+    `,
+    `
+                                      ██       
+              ███                    ██ ███    
+           ████ █ ████████████████████    ████ 
+         ███    ███               ███        █ 
+       ███      ██               ██          ██
+      ██         █                            █
+      █                                       █
+      █                                       █
+      █       ████████         █████████      █
+      █        ██               ██            █
+      █                                      ██
+      █     ███                      ███     █ 
+      █     █ █                      █ █    ██ 
+      ██      █                     ██     ██  
+       █      █                     █    ███   
+       ██     ██                    █   ██     
+        ███    █                    █ ████     
+       █████████                    ███  ██    
+     ███      ██                   ██     ██   
+   ███         █                   █       ██  
+  ██           ██                 ██        █  
+ ██             ██               ██         ██ 
+██       █       ███  █████████ ██           █ 
+█     █  █  █      ████       ███ █          █ 
+█     ██ ██ ██       ████   ████  █ █ █     ██ 
+█     █ █  █ █ █        █████    █ █ ██    ██  
+██    █      ██           █    █ █    █  ███   
+ ████ █      █                  ██    ████ █   
+  █  ██      █                   █████     █   
+  █    ██████                              █   
+    `,
+    `
+                                      ██       
+              ███                    ██ ███    
+           ████ █ ████████████████████    ████ 
+         ███    ███               ███        █ 
+       ███      ██               ██          ██
+      ██         █                            █
+      █                                       █
+      █                                       █
+      █       ████████         █████████      █
+      █       ██               ██             █
+      █                                      ██
+      █     ███                      ███     █ 
+      █     █ █                      █ █    ██ 
+      ██      █                     ██     ██  
+       █      █                     █    ███   
+       ██     ██                    █   ██     
+        ███    █                    █ ████     
+       █████████                    ███  ██    
+     ███      ██                   ██     ██   
+   ███         █                   █       ██  
+  ██           ██                 ██        █  
+ ██             ██               ██         ██ 
+██       █       ███  █████████ ██           █ 
+█     █  █  █      ████       ███ █          █ 
+█     ██ ██ ██       ████   ████  █ █ █     ██ 
+█     █ █  █ █ █        █████    █ █ ██    ██  
+██    █      ██           █    █ █    █  ███   
+ ████ █      █                  ██    ████ █   
+  █  ██      █                   █████     █   
+  █    ██████                              █   
+  `,
+  `
+                                      ██       
+              ███                    ██ ███    
+           ████ █ ████████████████████    ████ 
+         ███    ███               ███        █ 
+       ███      ██               ██          ██
+      ██         █                            █
+      █                                       █
+      █                                       █
+      █       ████████         █████████      █
+      █        ██               ██            █
+      █                                      ██
+      █     ███                      ███     █ 
+      █     █ █                      █ █    ██ 
+      ██      █                     ██     ██  
+       █      █                     █    ███   
+       ██     ██                    █   ██     
+        ███    █                    █ ████     
+       █████████                    ███  ██    
+     ███      ██                   ██     ██   
+   ███         █                   █       ██  
+  ██           ██                 ██        █  
+ ██             ██               ██         ██ 
+██       █       ███  █████████ ██           █ 
+█     █  █  █      ████       ███ █          █ 
+█     ██ ██ ██       ████   ████  █ █ █     ██ 
+█     █ █  █ █ █        █████    █ █ ██    ██  
+██    █      ██           █    █ █    █  ███   
+ ████ █      █                  ██    ████ █   
+  █  ██      █                   █████     █   
+  █    ██████                              █   
+  `,
+  `
+                                      ██       
+              ███                    ██ ███    
+           ████ █ ████████████████████    ████ 
+         ███    ███               ███        █ 
+       ███      ██               ██          ██
+      ██         █                            █
+      █                                       █
+      █                                       █
+      █       ████████         █████████      █
+      █          ██                ██         █
+      █                                      ██
+      █     ███                      ███     █ 
+      █     █ █                      █ █    ██ 
+      ██      █                     ██     ██  
+       █      █                     █    ███   
+       ██     ██                    █   ██     
+        ███    █                    █ ████     
+       █████████                    ███  ██    
+     ███      ██                   ██     ██   
+   ███         █                   █       ██  
+  ██           ██                 ██        █  
+ ██             ██               ██         ██ 
+██       █       ███  █████████ ██           █ 
+█     █  █  █      ████       ███ █          █ 
+█     ██ ██ ██       ████   ████  █ █ █     ██ 
+█     █ █  █ █ █        █████    █ █ ██    ██  
+██    █      ██           █    █ █    █  ███   
+ ████ █      █                  ██    ████ █   
+  █  ██      █                   █████     █   
+  █    ██████                              █   
+  `,
+  `
+                                      ██       
+              ███                    ██ ███    
+           ████ █ ████████████████████    ████ 
+         ███    ███               ███        █ 
+       ███      ██               ██          ██
+      ██         █                            █
+      █                                       █
+      █                        █████████      █
+      █       ████████             ██         █
+      █          ██                ██         █
+      █                                      ██
+      █     ███                      ███     █ 
+      █     █ █                      █ █    ██ 
+      ██      █                     ██     ██  
+       █      █                     █    ███   
+       ██     ██                    █   ██     
+        ███    █                    █ ████     
+       █████████                    ███  ██    
+     ███      ██                   ██     ██   
+   ███         █                   █       ██  
+  ██           ██                 ██        █  
+ ██             ██               ██         ██ 
+██       █       ███  █████████ ██           █ 
+█     █  █  █      ████       ███ █          █ 
+█     ██ ██ ██       ████   ████  █ █ █     ██ 
+█     █ █  █ █ █        █████    █ █ ██    ██  
+██    █      ██           █    █ █    █  ███   
+ ████ █      █                  ██    ████ █   
+  █  ██      █                   █████     █   
+  █    ██████                              █   
+  `,
+  `
+                                      ██       
+              ███                    ██ ███    
+           ████ █ ████████████████████    ████ 
+         ███    ███               ███        █ 
+       ███      ██               ██          ██
+      ██         █                            █
+      █                        █████████      █
+      █                            ██         █
+      █       ████████             ██         █
+      █          ██                ██         █
+      █                                      ██
+      █     ███                      ███     █ 
+      █     █ █                      █ █    ██ 
+      ██      █                     ██     ██  
+       █      █                     █    ███   
+       ██     ██                    █   ██     
+        ███    █                    █ ████     
+       █████████                    ███  ██    
+     ███      ██                   ██     ██   
+   ███         █                   █       ██  
+  ██           ██                 ██        █  
+ ██             ██               ██         ██ 
+██       █       ███  █████████ ██           █ 
+█     █  █  █      ████       ███ █          █ 
+█     ██ ██ ██       ████   ████  █ █ █     ██ 
+█     █ █  █ █ █        █████    █ █ ██    ██  
+██    █      ██           █    █ █    █  ███   
+ ████ █      █                  ██    ████ █   
+  █  ██      █                   █████     █   
+  █    ██████                              █   
+  `,
+  `
+                                      ██       
+              ███                    ██ ███    
+           ████ █ ████████████████████    ████ 
+         ███    ███               ███        █ 
+       ███      ██               ██          ██
+      ██         █                            █
+      █                                       █
+      █                        █████████      █
+      █       ████████             ██         █
+      █          ██                ██         █
+      █                                      ██
+      █     ███                      ███     █ 
+      █     █ █                      █ █    ██ 
+      ██      █                     ██     ██  
+       █      █                     █    ███   
+       ██     ██                    █   ██     
+        ███    █                    █ ████     
+       █████████                    ███  ██    
+     ███      ██                   ██     ██   
+   ███         █                   █       ██  
+  ██           ██                 ██        █  
+ ██             ██               ██         ██ 
+██       █       ███  █████████ ██           █ 
+█     █  █  █      ████       ███ █          █ 
+█     ██ ██ ██       ████   ████  █ █ █     ██ 
+█     █ █  █ █ █        █████    █ █ ██    ██  
+██    █      ██           █    █ █    █  ███   
+ ████ █      █                  ██    ████ █   
+  █  ██      █                   █████     █   
+  █    ██████                              █   
+  `
+    ];
+
+    const portraitFramesMerchant = [
+    ` 
+                              ██                                
+                            ███████                             
+     ▄▄█▀▀▀▀▀█            ███░░░░░███                           
+    ██░░    █           ███░░░░░░░░░██                          
+    █   ░░░█▀         ███░░░░░░░░░░░░██                         
+   ██░░░   █        ███░░░░░░░░░░░░░░░██                        
+   █   ░░░░█       ██░░░░░░░░░░░░░░░░░░██                       
+   █░░    ██       █░░░░░░░░░░░░░░░░░░░░░██                     
+  ██ ░░░░ █        █░░░░░░░░░░░░░░░░░░░░░░██                    
+  █      ██        █░░░░░░░░░░░░░░░░░░░░░░░███                  
+  █░░░░  ███████████░░░░░░░░░░░░░░░░░░░░░░░░░██                 
+  █   ░░░█░░░░░░░██░░░░░░░░░░░░░░░░░░░░░░░░░░░███               
+  █      █░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░██              
+  █░░    ███░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░███████        
+  █ ░░░░░█  ████████████░░░░░░░░░░░░░░░░░░░░░░░░░░░██░░██████   
+  █      ██    █████████████████░░░░░░░░░░░░░░░░░░░░██░░░░░░████
+  █░░░    █    ████████████████████████████████░░░░░░░░░░░░░████
+  █  ░░░░░█    ███████▓▓▓▓▓▓▓████████████████████████████████   
+  █      ░█    █████▓▓▓▓▓▓▓▓▓▓██████▓▓▓█████████▓█              
+  █░░░░  ██    ██  █▒▒▒▒▒▒▓▓▓▓▓▓████▓▓▓▓▓▓▓████▓██              
+  █   ░░██         ██  ▒▒▒▒▒▒▒▓▓▓██▓▓▓▒▒▒▒▒▒▒▒▒██               
+ ███████████▄       ██       ▒▒▒▒▓▓▒▒▒▒▒▒▒▒▒▒ ██                
+██          █▄    ▄▄█ █▄▄▄                 ▄██                  
+█      ▀▀▀▀▀▀▀█▄▄▀▀░░█▄  █▄▄▄▄     ▄▄▄▄▄▀▀▀█░▀██                
+█           ▄▄▀░░░░░░░▀█     ▀▀▀▀▀▀▀▀    ▄▄▀░░░▀█               
+██     ▀▀▀▀▀▄░░░░░░░░░░▀█▄         ▄▄▄▄▄▄█▀░░░░░░▀█             
+ █           █▄░░░░░█░░░░▀█▄     ▄██░░░░░░█░░░░░░░▀█            
+  █▄▄▄▄▄▄▄▄▄█▀▀█▄░░██░░░░░░█▄   █▀░░░░░░░░██░░░░░░░▀█           
+   █░   █       ▀███░░░░░░░░░▀▀▀░░░░░░░░░░░█░░░░░░░░█           
+   █░░░░█         ██░░░░░░░░░░░░░░░░░░░░░░░█░░░░░░░░▀█                         
+    `,
+    `
+                              ██                                
+     ▄▄█▀▀▀▀▀█              ███████                             
+    ██░░    █             ███░░░░░███                           
+    █   ░░░█▀           ███░░░░░░░░░██                          
+   ██░░░   █          ███░░░░░░░░░░░░██                         
+   █   ░░░░█        ███░░░░░░░░░░░░░░░██                        
+   █░░    ██       ██░░░░░░░░░░░░░░░░░░██                       
+  ██ ░░░░ █        █░░░░░░░░░░░░░░░░░░░░░██                     
+  █      ██        █░░░░░░░░░░░░░░░░░░░░░░██                    
+  █░░░░  █         █░░░░░░░░░░░░░░░░░░░░░░░███                  
+  █   ░░░███████████░░░░░░░░░░░░░░░░░░░░░░░░░██                 
+  █      █░░░░░░░██░░░░░░░░░░░░░░░░░░░░░░░░░░░███               
+  █░░    █░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░██              
+  █ ░░░░░███░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░███████        
+  █      ██ ████████████░░░░░░░░░░░░░░░░░░░░░░░░░░░██░░██████   
+  █░░░    █    █████████████████░░░░░░░░░░░░░░░░░░░░██░░░░░░████
+  █  ░░░░░█    ████████████████████████████████░░░░░░░░░░░░░████
+  █      ░█    ███████▓▓▓▓▓▓▓████████████████████████████████   
+  █░░░░  ██    █████▓▓▓▓▓▓▓▓▓▓██████▓▓▓█████████▓█              
+  █    ▒▒█     ██  █▒▒▒▒▒▒▓▓▓▓▓▓████▓▓▓▓▓▓▓████▓██              
+ ███████████▄      ██  ▒▒▒▒▒▒▒▓▓▓██▓▓▓▒▒▒▒▒▒▒▒▒██               
+██          █▄    ▄▄██       ▒▒▒▒▓▓▒▒▒▒▒▒▒▒▒▒ ██                
+█      ▀▀▀▀▀▀▀█▄▄▀▀░█ █▄▄▄                 ▄██                  
+█           ▄▄▀░░░░░░█▄  █▄▄▄▄     ▄▄▄▄▄▀▀▀█░▀██                
+██     ▀▀▀▀▀▄░░░░░░░░░▀█     ▀▀▀▀▀▀▀▀    ▄▄▀░░░▀█               
+ █           █▄░░░░░░░░▀█▄         ▄▄▄▄▄▄█▀░░░░░░▀█             
+  █▄▄▄▄▄▄▄▄▄█▀█░░░░░█░░░░▀█▄     ▄██░░░░░░█░░░░░░░▀█            
+   █    █      █▄░░██░░░░░░█▄   █▀░░░░░░░░██░░░░░░░▀█           
+   █░   █       ▀███░░░░░░░░░▀▀▀░░░░░░░░░░░█░░░░░░░░█           
+   █░░░░█         ██░░░░░░░░░░░░░░░░░░░░░░░█░░░░░░░░▀█                        
+    `,
+    `
+     ▄▄█▀▀▀▀▀█                ██                                
+    ██░░    █               ███████                             
+    █   ░░░█▀             ███░░░░░███                           
+   ██░░░   █            ███░░░░░░░░░██                          
+   █   ░░░░█          ███░░░░░░░░░░░░██                         
+   █░░    ██        ███░░░░░░░░░░░░░░░██                        
+  ██ ░░░░ █        ██░░░░░░░░░░░░░░░░░░██                       
+  █   ░░░█         █░░░░░░░░░░░░░░░░░░░░░██                     
+  █      █         █░░░░░░░░░░░░░░░░░░░░░░██                    
+  █░░    █         █░░░░░░░░░░░░░░░░░░░░░░░███                  
+  █ ░░░░░███████████░░░░░░░░░░░░░░░░░░░░░░░░░██                 
+  █      █░░░░░░░██░░░░░░░░░░░░░░░░░░░░░░░░░░░███               
+  █░░░   █░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░██              
+  █  ░░░░░██░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░███████        
+  █      ░█ ████████████░░░░░░░░░░░░░░░░░░░░░░░░░░░██░░██████   
+  █       █    █████████████████░░░░░░░░░░░░░░░░░░░░██░░░░░░████
+  █░░░░   █    ████████████████████████████████░░░░░░░░░░░░░████
+  █   ░░░█     ███████▓▓▓▓▓▓▓████████████████████████████████   
+  █      █     █████▓▓▓▓▓▓▓▓▓▓██████▓▓▓█████████▓█              
+ ███████████▄  ██  █▒▒▒▒▒▒▓▓▓▓▓▓████▓▓▓▓▓▓▓████▓██              
+██          █▄     ██  ▒▒▒▒▒▒▒▓▓▓██▓▓▓▒▒▒▒▒▒▒▒▒██               
+█      ▀▀▀▀▀▀▀█▄▄▄▄▄██       ▒▒▒▒▓▓▒▒▒▒▒▒▒▒▒▒ ██                
+█           ▄▄▀░░░░░█ █▄▄▄                 ▄██                  
+██     ▀▀▀▀▀▄░░░░░░░░█▄  █▄▄▄▄     ▄▄▄▄▄▀▀▀█░▀██                
+ █           █░░░░░░░░▀█     ▀▀▀▀▀▀▀▀    ▄▄▀░░░▀█               
+  █▄▄▄▄▄▄▄▄▄█▀█░░░░░░░░▀█▄         ▄▄▄▄▄▄█▀░░░░░░▀█             
+   █    █      █▄░░░█░░░░▀█▄     ▄██░░░░░░█░░░░░░░▀█            
+   █░   █       ▀█░██░░░░░░█▄   █▀░░░░░░░░██░░░░░░░▀█           
+   █░░░░█         ██░░░░░░░░░▀▀▀░░░░░░░░░░░█░░░░░░░░█           
+   █  ░░█         ██░░░░░░░░░░░░░░░░░░░░░░░█░░░░░░░░▀█                   
+    `,
+    `
+     ▄▄█▀▀▀▀▀█                ██                                
+    ██░░    █               ███████                             
+    █   ░░░█▀             ███░░░░░███                           
+   ██░░░   █            ███░░░░░░░░░██                          
+   █   ░░░░█          ███░░░░░░░░░░░░██                         
+   █░░    ██        ███░░░░░░░░░░░░░░░██                        
+  ██ ░░░░ █        ██░░░░░░░░░░░░░░░░░░██                       
+  █   ░░░█         █░░░░░░░░░░░░░░░░░░░░░██                     
+  █      █         █░░░░░░░░░░░░░░░░░░░░░░██                    
+  █░░    █         █░░░░░░░░░░░░░░░░░░░░░░░███                  
+  █ ░░░░░███████████░░░░░░░░░░░░░░░░░░░░░░░░░██                 
+  █      █░░░░░░░██░░░░░░░░░░░░░░░░░░░░░░░░░░░███               
+  █░░░   █░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░██              
+  █  ░░░░░██░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░███████        
+  █      ░█ ████████████░░░░░░░░░░░░░░░░░░░░░░░░░░░██░░██████   
+  █       █    █████████████████░░░░░░░░░░░░░░░░░░░░██░░░░░░████
+  █░░░░   █    ████████████████████████████████░░░░░░░░░░░░░████
+  █   ░░░█     ███████▓▓▓▓▓▓▓████████████████████████████████   
+  █      █     █████▓▓▓▓▓▓▓▓▓▓██████▓▓▓█████████▓█              
+ ███████████▄  ██  █▒▒▒▒▒▒▓▓▓▓▓▓████▓▓▓▓▓▓▓████▓██              
+██          █▄     ██  ▒▒▒▒▒▒▒▓▓▓██▓▓▓▒▒▒▒▒▒▒▒▒██               
+█      ▀▀▀▀▀▀▀█▄▄▄▄▄██       ▒▒▒▒▓▓▒▒▒▒▒▒▒▒▒▒ ██                
+█           ▄▄▀░░░░░█ █▄▄▄                 ▄██                  
+██     ▀▀▀▀▀▄░░░░░░░░█▄  █▄▄▄▄     ▄▄▄▄▄▀▀▀█░▀██                
+ █           █░░░░░░░░▀█     ▀▀▀▀▀▀▀▀    ▄▄▀░░░▀█               
+  █▄▄▄▄▄▄▄▄▄█▀█░░░░░░░░▀█▄         ▄▄▄▄▄▄█▀░░░░░░▀█             
+   █    █      █▄░░░█░░░░▀█▄     ▄██░░░░░░█░░░░░░░▀█            
+   █░   █       ▀█░██░░░░░░█▄   █▀░░░░░░░░██░░░░░░░▀█           
+   █░░░░█         ██░░░░░░░░░▀▀▀░░░░░░░░░░░█░░░░░░░░█           
+   █  ░░█         ██░░░░░░░░░░░░░░░░░░░░░░░█░░░░░░░░▀█                  
+    `,
+    `
+                              ██                                
+     ▄▄█▀▀▀▀▀█              ███████                             
+    ██░░    █             ███░░░░░███                           
+    █   ░░░█▀           ███░░░░░░░░░██                          
+   ██░░░   █          ███░░░░░░░░░░░░██                         
+   █   ░░░░█        ███░░░░░░░░░░░░░░░██                        
+   █░░    ██       ██░░░░░░░░░░░░░░░░░░██                       
+  ██ ░░░░ █        █░░░░░░░░░░░░░░░░░░░░░██                     
+  █      ██        █░░░░░░░░░░░░░░░░░░░░░░██                    
+  █░░░░  █         █░░░░░░░░░░░░░░░░░░░░░░░███                  
+  █   ░░░███████████░░░░░░░░░░░░░░░░░░░░░░░░░██                 
+  █      █░░░░░░░██░░░░░░░░░░░░░░░░░░░░░░░░░░░███               
+  █░░    █░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░██              
+  █ ░░░░░███░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░███████        
+  █      ██ ████████████░░░░░░░░░░░░░░░░░░░░░░░░░░░██░░██████   
+  █░░░    █    █████████████████░░░░░░░░░░░░░░░░░░░░██░░░░░░████
+  █  ░░░░░█    ████████████████████████████████░░░░░░░░░░░░░████
+  █      ░█    ███████▓▓▓▓▓▓▓████████████████████████████████   
+  █░░░░  ██    █████▓▓▓▓▓▓▓▓▓▓██████▓▓▓█████████▓█              
+  █    ▒▒█     ██  █▒▒▒▒▒▒▓▓▓▓▓▓████▓▓▓▓▓▓▓████▓██              
+ ███████████▄      ██  ▒▒▒▒▒▒▒▓▓▓██▓▓▓▒▒▒▒▒▒▒▒▒██               
+██          █▄    ▄▄██       ▒▒▒▒▓▓▒▒▒▒▒▒▒▒▒▒ ██                
+█      ▀▀▀▀▀▀▀█▄▄▀▀░█ █▄▄▄                 ▄██                  
+█           ▄▄▀░░░░░░█▄  █▄▄▄▄     ▄▄▄▄▄▀▀▀█░▀██                
+██     ▀▀▀▀▀▄░░░░░░░░░▀█     ▀▀▀▀▀▀▀▀    ▄▄▀░░░▀█               
+ █           █▄░░░░░░░░▀█▄         ▄▄▄▄▄▄█▀░░░░░░▀█             
+  █▄▄▄▄▄▄▄▄▄█▀█░░░░░█░░░░▀█▄     ▄██░░░░░░█░░░░░░░▀█            
+   █    █      █▄░░██░░░░░░█▄   █▀░░░░░░░░██░░░░░░░▀█           
+   █░   █       ▀███░░░░░░░░░▀▀▀░░░░░░░░░░░█░░░░░░░░█           
+   █░░░░█         ██░░░░░░░░░░░░░░░░░░░░░░░█░░░░░░░░▀█                          
+    `,
+    `
+                              ██                                
+                            ███████                             
+     ▄▄█▀▀▀▀▀█            ███░░░░░███                           
+    ██░░    █           ███░░░░░░░░░██                          
+    █   ░░░█▀         ███░░░░░░░░░░░░██                         
+   ██░░░   █        ███░░░░░░░░░░░░░░░██                        
+   █   ░░░░█       ██░░░░░░░░░░░░░░░░░░██                       
+   █░░    ██       █░░░░░░░░░░░░░░░░░░░░░██                     
+  ██ ░░░░ █        █░░░░░░░░░░░░░░░░░░░░░░██                    
+  █      ██        █░░░░░░░░░░░░░░░░░░░░░░░███                  
+  █░░░░  ███████████░░░░░░░░░░░░░░░░░░░░░░░░░██                 
+  █   ░░░█░░░░░░░██░░░░░░░░░░░░░░░░░░░░░░░░░░░███               
+  █      █░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░██              
+  █░░    ███░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░███████        
+  █ ░░░░░█  ████████████░░░░░░░░░░░░░░░░░░░░░░░░░░░██░░██████   
+  █      ██    █████████████████░░░░░░░░░░░░░░░░░░░░██░░░░░░████
+  █░░░    █    ████████████████████████████████░░░░░░░░░░░░░████
+  █  ░░░░░█    ███████▓▓▓▓▓▓▓████████████████████████████████   
+  █      ░█    █████▓▓▓▓▓▓▓▓▓▓██████▓▓▓█████████▓█              
+  █░░░░  ██    ██  █▒▒▒▒▒▒▓▓▓▓▓▓████▓▓▓▓▓▓▓████▓██              
+  █   ░░██         ██  ▒▒▒▒▒▒▒▓▓▓██▓▓▓▒▒▒▒▒▒▒▒▒██               
+ ███████████▄       ██       ▒▒▒▒▓▓▒▒▒▒▒▒▒▒▒▒ ██                
+██          █▄    ▄▄█ █▄▄▄                 ▄██                  
+█      ▀▀▀▀▀▀▀█▄▄▀▀░░█▄  █▄▄▄▄     ▄▄▄▄▄▀▀▀█░▀██                
+█           ▄▄▀░░░░░░░▀█     ▀▀▀▀▀▀▀▀    ▄▄▀░░░▀█               
+██     ▀▀▀▀▀▄░░░░░░░░░░▀█▄         ▄▄▄▄▄▄█▀░░░░░░▀█             
+ █           █▄░░░░░█░░░░▀█▄     ▄██░░░░░░█░░░░░░░▀█            
+  █▄▄▄▄▄▄▄▄▄█▀▀█▄░░██░░░░░░█▄   █▀░░░░░░░░██░░░░░░░▀█           
+   █░   █       ▀███░░░░░░░░░▀▀▀░░░░░░░░░░░█░░░░░░░░█           
+   █░░░░█         ██░░░░░░░░░░░░░░░░░░░░░░░█░░░░░░░░▀█                  
+    `,
+    ];
+
+    const portraitFramesSettings = [
+    `
+                                                                 
+                        ███████████                              
+                        █         █         ██                   
+               ████     █         █       █████                  
+           █████  ███   █         █      ██   ███                
+       █████        ██  █         █    ███      ███              
+      ██            ████           ████           ███            
+       ██                                           ██           
+         ██                                       ███            
+          ███                                   ███              
+            █                                 ███                
+            █            ███████              █                  
+    █████████          ██       ██            █████████          
+    █                 █           █                   █          
+    █                 █           █                   █          
+    █                 █           █                   █          
+    █████████          ██       ██            █████████          
+            █            ███████              █                  
+           ██                                 ██                 
+        ████                                   ███               
+       ██                                        ███             
+      ██                                            ██           
+      ██             ███           ███           ████            
+       ██           ██  █         █  ███      ████               
+        ███      ████   █         █    ███  ███                  
+          ██  ████      █         █      ████                    
+           ████         █         █                              
+                        ███████████                                                                                                                                                                                                                                                                    
+    `,
+    `
+                       ██████                              
+                 ███████    ██       █████                 
+                 ██          █     ███   █████             
+                  █          █   ███         █████         
+                  ██         ██ ██              ██         
+      ██████       ██        █████            ██           
+     ██    ████     ██                       ██            
+    ██         █████                       ███             
+   ██                                      █               
+  ██                                        █              
+  █████                                      ██   ████████ 
+      ████               ███████              █████      ██
+         ███           ██       ██                        █
+           █          █           █                       █
+           █          █           █                       █
+           █          █           █                       █
+       █████           ██       ██             ████████████
+ ███████                 ███████              █            
+█                                            ██            
+██                                           ██            
+ ██     █████████                             ██           
+  ██████         ███                           ██          
+                   █               ████         ██         
+                  ██         ██████   ██          █        
+                  █         █          ███     ████        
+                ███       ██              ██████           
+               ███      ███                                
+                 ████████                                                                                                
+    `
+    ];
+
+    const portraitFramesChest = [
+    `
+                                                                 
+                                                                 
+                                                                 
+                                                                 
+                                                                 
+                                                                 
+                                                                 
+                                                                 
+                      ▄▄▄▄▄▄▄▄▄▄▄                                
+                ▄▀▀▀▀▀▀         ▀▀▀▀▀▀▀█▄▄▄▄                     
+            ▄█▀▀                         █▀▀█▄▄                  
+          ▄█▀                           ▄▀   ▀▀█▄                
+         ▄█                           ▄█        ▀█▄              
+       ▄█▀                            █           ▀█▄            
+       █                             █▀             ▀▄           
+      █▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄█▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄█          
+      █         █        █           █                █          
+      █         █  ████  █           █                █          
+      █         █   ██   █           █                █          
+      █         █▄▄▄▄▄▄▄▄█           █                █          
+      █                              █                █          
+      █                              █                █          
+      █                              █                █          
+      █                              █                █          
+      █                              █                █          
+      █                              █                █          
+      █                              █                █          
+      █                              █                █          
+      █                              █                █          
+       ▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀                        
+    `,
+    `
+                                                                 
+                                                                 
+                                                                 
+                                                                 
+                                                                 
+                                                                 
+                                                                 
+                  ▄█▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▄▄▄                    
+              ▄█▀▀▀                       █▀▀▀▀█                 
+            ▄█▀                          █▀    ▀▀▀▀█             
+         ▄█▀▀                          █▀          ▀▀█           
+        ▄█                            █▀             ▀█          
+      ▄▄█                             █               █          
+      ▀▀▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄           █▀               █          
+            ██████████████▄▄▄▄▄▄▄▄▄▄▄█▄▄▄▄▄▄▄         █          
+      ▄▄▄▄▄▄▄▄█████████████████████████████████████████          
+      █         █        █           █                █          
+      █         █  ████  █           █                █          
+      █         █   ██   █           █                █          
+      █         █▄▄▄▄▄▄▄▄█           █                █          
+      █                              █                █          
+      █                              █                █          
+      █                              █                █          
+      █                              █                █          
+      █                              █                █          
+      █                              █                █          
+      █                              █                █          
+      █                              █                █          
+      █                              █                █          
+       ▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀                        
+    `
+    ];
+
 
     // --- TITLE SCREEN LOGIC ---
     const $titleScreen = document.getElementById('titleScreen');

--- a/src/game.html
+++ b/src/game.html
@@ -42,6 +42,7 @@
             display: flex;
             box-sizing: content-box;
             user-select: none;
+            overflow: hidden;
         }
 
         a:visited,


### PR DESCRIPTION
Whenever you enter a menu or NPC interaction, the minimap area is replaced by an animated ASCII portrait. Currently this covers the settings, menu, merchant, and gambler menus. More can be added later for the submenus.

Example video:


https://github.com/user-attachments/assets/0f65b916-cf11-4282-89c8-1654b9fa4973



I also debuffed the LOAD gain when levelling END because you really just don't get heavy often enough