### PR TITLE
Optimize Minimap Rendering Function

### DIFF
--- a/src/game.html
+++ b/src/game.html
@@ -10046,7 +10046,9 @@ A Javascript game by <a href="https://milklounge.wang/tardquest/" target="_blank
             if (awaitingPersuasionText) return;
 
             if (menu.isOpen()) {
-                menu.handleInput(key);
+                if (! animationActive) {
+                    menu.handleInput(key);
+                }
             } else if (key === 'escape' && !awaitingPersuasionText) {
                 menu.open('gameSettings');
             } else if (key === 'i') {

--- a/src/game.html
+++ b/src/game.html
@@ -606,6 +606,7 @@
         }
 
         #minimap .crackedFloorSlight,
+        #minimap .crackedFloor,
         #minimap .crackedFloorSevere {
             color: #f00;
         }
@@ -945,6 +946,7 @@
         }
 
         .scene_character_crackedFloorSlight,
+        .scene_character_crackedFloor,
         .scene_character_crackedFloorSevere {
             color: #000;
         }
@@ -4526,6 +4528,250 @@ A Javascript game by <a href="https://milklounge.wang/tardquest/" target="_blank
                         automaskBlockCharacters: true,
                         transparentCharacter: '%',
                         data: `
+                            %%▀▀█▀▀▄%%▄▄
+                            ▀▀▀▀%%%%%%%%%%%%▀▄
+                            %%%%%%%%%%%%%%%%%%▀▀
+                        `
+                    },
+                    {
+                        automaskBlockCharacters: true,
+                        transparentCharacter: '%',
+                        data: `
+                            %%%%%%%%▄
+                            %%%%%%%%%▀▀█▀▀▄
+                            %%%%%%%▀▀▀▀%%%%%%%%%%%%%%▀▀▄
+                            %%%%%%%%%%%%%%%%%%%%%%%%%%%%▀▀
+                        `,
+                    },
+                    {
+                        automaskBlockCharacters: true,
+                        transparentCharacter: '%',
+                        data: `
+                            ▘%▗▄▖
+                            %▀▘%%▄
+                        `,
+                    },
+                    {
+                        automaskBlockCharacters: true,
+                        transparentCharacter: '%',
+                        data: `
+                            %%%%%%▄%%%%%▖
+                            %%%▀▀▀%%%%%%▝▄
+                        `
+                    },
+                    {
+                        automaskBlockCharacters: true,
+                        transparentCharacter: '%',
+                        data: `
+                            %%%%▄▄%%%%▗▄▖
+                            %▀▀▀%%%%%%%%▝▄
+                        `,
+                    },
+                    {
+                        automaskBlockCharacters: true,
+                        transparentCharacter: '%',
+                        data: `
+                            %%%%%▄%%%▗▄▖
+                            %%%▀▀▀%%%%%▝▄
+                        `,
+                    },
+                    {
+                        automaskBlockCharacters: true,
+                        transparentCharacter: '%',
+                        data: `
+                            %░░%░%%%░░%%░
+                        `,
+                    },
+                    {
+                        automaskBlockCharacters: true,
+                        transparentCharacter: '%',
+                        data: `
+                            %░░%░░%%░
+                        `,
+                    },
+                    {
+                        automaskBlockCharacters: true,
+                        transparentCharacter: '%',
+                        data: `
+                            %▔%%▔
+                        `,
+                    },
+                    {
+                        automaskBlockCharacters: true,
+                        data: `
+                            ╶╴
+                        `,
+                    },
+                    {
+                        automaskBlockCharacters: true,
+                        transparentCharacter: '%',
+                        data: `
+                            %%▒░▒▒░▒
+                        `,
+                    },
+                ],
+            },
+
+            crackedFloor: {
+                positions: {
+                    p0_0: {
+                        artIndex: 0,
+                        drawAt: { x: -19, y: 24 },
+                    },
+                    p0_2: {
+                        artIndex: 0,
+                        drawAt: { x: 45, y: 24 },
+                    },
+                    p1_0: {
+                        artIndex: 0,
+                        drawAt: { x: -12, y: 20 },
+                    },
+                    p1_1: {
+                        artIndex: 1,
+                        drawAt: { x: 8, y: 20 },
+                    },
+                    p1_2: {
+                        artIndex: 0,
+                        drawAt: { x: 38, y: 20 },
+                    },
+                    p2_0: {
+                        artIndex: 2,
+                        drawAt: { x: 0, y: 18 },
+                    },
+                    p2_1: {
+                        artIndex: 3,
+                        drawAt: { x: 3, y: 17 },
+                    },
+                    p2_2: {
+                        artIndex: 4,
+                        drawAt: { x: 16, y: 17 },
+                    },
+                    p2_3: {
+                        artIndex: 5,
+                        drawAt: { x: 32, y: 17 },
+                    },
+                    p2_4: {
+                        artIndex: 2,
+                        drawOptions: { flippedX: true },
+                        drawAt: { x: 42, y: 18 },
+                    },
+                    p3_0: {
+                        artIndex: 10,
+                        drawAt: { x: -9, y: 15 },
+                    },
+                    p3_1: {
+                        artIndex: 10,
+                        drawAt: { x: -3, y: 16 },
+                    },
+                    p3_2: {
+                        artIndex: 10,
+                        drawAt: { x: 8, y: 16 },
+                    },
+                    p3_3: {
+                        artIndex: 7,
+                        drawAt: { x: 20, y: 16 },
+                    },
+                    p3_4: {
+                        artIndex: 10,
+                        drawOptions: { flippedX: true },
+                        drawAt: { x: 29, y: 16 },
+                    },
+                    p3_5: {
+                        artIndex: 10,
+                        drawOptions: { flippedX: true },
+                        drawAt: { x: 36, y: 16 },
+                    },
+                    p3_6: {
+                        artIndex: 10,
+                        drawOptions: { flippedX: true },
+                        drawAt: { x: 46, y: 15 },
+                    },
+                    p4_0: {
+                        artIndex: 8,
+                        drawAt: { x: 2, y: 15 },
+                    },
+                    p4_1: {
+                        artIndex: 8,
+                        drawAt: { x: 7, y: 15 },
+                    },
+                    p4_2: {
+                        artIndex: 8,
+                        drawAt: { x: 12, y: 15 },
+                    },
+                    p4_3: {
+                        artIndex: 8,
+                        drawAt: { x: 17, y: 15 },
+                    },
+                    p4_4: {
+                        artIndex: 8,
+                        drawAt: { x: 22, y: 15 },
+                    },
+                    p4_5: {
+                        artIndex: 8,
+                        drawAt: { x: 27, y: 15 },
+                    },
+                    p4_6: {
+                        artIndex: 8,
+                        drawAt: { x: 32, y: 15 },
+                    },
+                    p4_7: {
+                        artIndex: 8,
+                        drawAt: { x: 37, y: 15 },
+                    },
+                    p4_8: {
+                        artIndex: 8,
+                        drawAt: { x: 42, y: 15 },
+                    },
+                    p5_0: {
+                        artIndex: 9,
+                        drawAt: { x: 14, y: 14 },
+                    },
+                    p5_1: {
+                        artIndex: 9,
+                        drawAt: { x: 16, y: 14 },
+                    },
+                    p5_2: {
+                        artIndex: 9,
+                        drawAt: { x: 18, y: 14 },
+                    },
+                    p5_3: {
+                        artIndex: 9,
+                        drawAt: { x: 20, y: 14 },
+                    },
+                    p5_4: {
+                        artIndex: 9,
+                        drawAt: { x: 22, y: 14 },
+                    },
+                    p5_5: {
+                        artIndex: 9,
+                        drawAt: { x: 24, y: 14 },
+                    },
+                    p5_6: {
+                        artIndex: 9,
+                        drawAt: { x: 26, y: 14 },
+                    },
+                    p5_7: {
+                        artIndex: 9,
+                        drawAt: { x: 28, y: 14 },
+                    },
+                    p5_8: {
+                        artIndex: 9,
+                        drawAt: { x: 30, y: 14 },
+                    },
+                    p5_9: {
+                        artIndex: 9,
+                        drawAt: { x: 32, y: 14 },
+                    },
+                    p5_10: {
+                        artIndex: 9,
+                        drawAt: { x: 34, y: 14 },
+                    },
+                },
+                art: [
+                    {
+                        automaskBlockCharacters: true,
+                        transparentCharacter: '%',
+                        data: `
                             %%▀▀█▀▀▄▄▄▄▄%%▄▀
                             ▀▀▀▀%%%%%%▄▄▄▀▀▀▀▄
                             %%%%%%%%%%%%%%%%%%▀▀
@@ -6684,8 +6930,8 @@ A Javascript game by <a href="https://milklounge.wang/tardquest/" target="_blank
                     speed: player.speed + getRingEffect('speed'),
                     luck: player.luck + getRingEffect('luck'),
                     endurance: player.endurance,
-                    carryWeight: getCarryWeight(),
-                    carryWeightLimit: getCarryWeightLimit(),
+                    carryWeight: player.getCarryWeight(),
+                    carryWeightLimit: player.getCarryWeightLimit(),
                 };
             },
             refreshStats: () => {
@@ -6788,6 +7034,66 @@ A Javascript game by <a href="https://milklounge.wang/tardquest/" target="_blank
                 player.exp = rolledOverExp;
                 player.hp = getEffectiveStat('maxHp');
                 document.getElementById('playerLevel').innerText = player.level;
+            },
+            getCarryWeight: () => {
+                let total = 0;
+
+                // 1. Consumables
+                for (const itemId in player.inventory) {
+                    if (weapons[itemId] || armor[itemId] || rings[itemId]) {
+                        continue;
+                    }
+
+                    const item = items[itemId];
+                    if (typeof item?.weight === "number") {
+                        total += item.weight * player.inventory[itemId];
+                    }
+                }
+
+                // 2. Weapons
+                for (const weaponId in weapons) {
+                    let count = player.inventory[weaponId] || 0;
+                    if (player.weapon === weaponId && count === 0) {
+                        count = 1;
+                    }
+                    total += weapons[weaponId].weight * count;
+                }
+
+                // 3. Armor
+                for (const armorId in armor) {
+                    let count = player.inventory[armorId] || 0;
+                    if (player.armor === armorId && count === 0) {
+                        count = 1;
+                    }
+                    total += armor[armorId].weight * count;
+                }
+
+                // 4. Rings
+                for (const ringId in rings) {
+                    let count = player.inventory[ringId] || 0;
+                    if (player.ring1 === ringId && count === 0) {
+                        count += 1;
+                    }
+                    if (player.ring2 === ringId && count === 0 && player.ring1 !== ringId) {
+                        count += 1;
+                    }
+                    total += rings[ringId].weight * count;
+                }
+
+                return total;
+            },
+            getCarryWeightLimit: () => {
+                // Example: 35 base + 0.6 per END point
+                return 35 + (player.endurance * 0.4);
+            },
+            // Returns "normal", "warning", or "danger" depending on load
+            getWeightLevel: () => {
+                const percentage =
+                    player.getCarryWeight() / player.getCarryWeightLimit();
+
+                return percentage < 0.5
+                    ? "normal"
+                    : (percentage < 0.8 ? "warning" : "danger");
             },
             fallThroughFloorAndDie: () => {
                 setTimeout(() => {
@@ -7934,16 +8240,21 @@ A Javascript game by <a href="https://milklounge.wang/tardquest/" target="_blank
         };
 
         function getEffectiveStat(stat) {
-                if (stat === 'speed') {
-                    const baseSpd = player.speed;
-                    const carryWeight = getCarryWeight();
-                    const carryLimit = getCarryWeightLimit();
-                    if (carryWeight <= 0) return baseSpd;
-                    const percent = carryWeight / carryLimit;
-                    if (percent <= 0.5) return baseSpd; // Debuff: 5% at 50%, up to 100% at 100%
-                    const debuff = Math.min(1, (percent - 0.5) * 2) * 0.95 + 0.05; // Linear from 5% to 100%
-                    return Math.max(0, Math.floor(baseSpd * (1 - debuff)));
+            if (stat === 'speed') {
+                const baseSpd = player.speed;
+                const carryWeight = player.getCarryWeight();
+                const carryLimit = player.getCarryWeightLimit();
+                if (carryWeight <= 0) {
+                    return baseSpd;
                 }
+                const percent = carryWeight / carryLimit;
+                if (percent <= 0.5) {
+                    return baseSpd; // Debuff: 5% at 50%, up to 100% at 100%
+                }
+                const debuff = Math.min(1, (percent - 0.5) * 2) * 0.95 + 0.05; // Linear from 5% to 100%
+                return Math.max(0, Math.floor(baseSpd * (1 - debuff)));
+            }
+
             const ringsEquipped = [player.ring1, player.ring2]
                 .map(ringId => ringId ? rings[ringId] : null)
                 .filter(Boolean);
@@ -8099,31 +8410,43 @@ A Javascript game by <a href="https://milklounge.wang/tardquest/" target="_blank
                 displayName: "Slightly-Cracked Floor",
                 mapCharacter: '✕',
                 onEnter: function (x, y) {
-                    const key = `${x},${y}`;
-                    // Determine step threshold based on carry weight
-                    const percent = getCarryWeight() / getCarryWeightLimit();
-                    let threshold = 3;
-                    if (percent >= 0.8) threshold = 1;
-                    else if (percent >= 0.5) threshold = 2;
+                    const weightLevel = player.getWeightLevel();
 
-                    crackedFloorSteps[key] = (crackedFloorSteps[key] || 0) + 1;
+                    if (weightLevel === "normal") {
+                        MAP.setCell(x, y, "crackedFloor");
+                        playSFX("floorCrackSlight");
+                        updateBattleLog(
+                            '<span class="action">The floor cracks under ' +
+                            'your feet!</span>'
+                        );
+                    } else if (weightLevel === "warning") {
+                        MAP.setCell(x, y, "crackedFloorSevere");
+                        playSFX("floorCrackSlight");
+                        updateBattleLog(
+                            '<span class="action">The floor trembles under ' +
+                            'your feet!</span> You might want to lighten ' +
+                            'your load and avoid stepping here again!'
+                        );
+                    } else if (weightLevel === "danger") {
+                        player.fallThroughFloorAndDie();
+                    }
+                },
+            },
+            crackedFloor: {
+                displayName: "Cracked Floor",
+                mapCharacter: '✕',
+                onEnter: function (x, y) {
+                    const weightLevel = player.getWeightLevel();
 
-                    if (crackedFloorSteps[key] < threshold) {
-                        // Not yet breaking, but upgrade to severe if not already
-                        /*
-                        if (MAP[y][x].type !== 'crackedFloorSevere') {
-                            MAP[y][x] = new MapCell(
-                                'crackedFloorSevere',
-                                { x, y, $element: this.$element }
-                            );
-                            updateBattleLog(
-                                '<span class="action">The floor cracks under ' +
-                                'your feet!</span>'
-                            );
-                            playSFX('floorCrackSlight');
-                        }
-                        */
-                    } else {
+                    if (weightLevel === "normal") {
+                        MAP.setCell(x, y, "crackedFloorSevere");
+                        playSFX("floorCrackSlight");
+                        updateBattleLog(
+                            '<span class="action">The floor cracks under ' +
+                            'your feet!</span> It would be a good idea to ' +
+                            'avoid stepping here again'
+                        );
+                    } else if (["warning", "danger"].includes(weightLevel)) {
                         player.fallThroughFloorAndDie();
                     }
                 },
@@ -8132,24 +8455,7 @@ A Javascript game by <a href="https://milklounge.wang/tardquest/" target="_blank
                 displayName: "Severely-Cracked Floor",
                 mapCharacter: '✖',
                 onEnter: function (x, y) {
-                    const key = `${x},${y}`;
-                    // Determine step threshold based on carry weight
-                    const percent = getCarryWeight() / getCarryWeightLimit();
-                    let threshold = 3;
-                    if (percent >= 0.8) threshold = 1;
-                    else if (percent >= 0.5) threshold = 2;
-
-                    crackedFloorSteps[key] = (crackedFloorSteps[key] || 0) + 1;
-
-                    if (crackedFloorSteps[key] < threshold) {
-                        // Still not breaking, but warn
-                        updateBattleLog(
-                            '<span class="action">The floor cracks even more under your feet!</span> One more step and you\'re done for!'
-                        );
-                        playSFX('floorCrackSlight');
-                    } else {
-                        player.fallThroughFloorAndDie();
-                    }
+                    player.fallThroughFloorAndDie();
                 },
             },
             rubble1: {
@@ -8855,48 +9161,6 @@ A Javascript game by <a href="https://milklounge.wang/tardquest/" target="_blank
             render();
         }
 
-        function getCarryWeight() {
-            let total = 0;
-
-            // 1. Consumables
-            for (const itemId in player.inventory) {
-                if (weapons[itemId] || armor[itemId] || rings[itemId]) continue;
-                const item = items[itemId];
-                if (item && typeof item.weight === "number") {
-                    total += item.weight * player.inventory[itemId];
-                }
-            }
-
-            // 2. Weapons
-            for (const weaponId in weapons) {
-                let count = player.inventory[weaponId] || 0;
-                if (player.weapon === weaponId && count === 0) count = 1;
-                total += weapons[weaponId].weight * count;
-            }
-
-            // 3. Armor
-            for (const armorId in armor) {
-                let count = player.inventory[armorId] || 0;
-                if (player.armor === armorId && count === 0) count = 1;
-                total += armor[armorId].weight * count;
-            }
-
-            // 4. Rings
-            for (const ringId in rings) {
-                let count = player.inventory[ringId] || 0;
-                if (player.ring1 === ringId && count === 0) count += 1;
-                if (player.ring2 === ringId && count === 0 && player.ring1 !== ringId) count += 1;
-                total += rings[ringId].weight * count;
-            }
-
-            return total;
-        }
-
-        function getCarryWeightLimit() {
-            // Example: 35 base + 0.6 per END point
-            return 35 + player.endurance * 0.4;
-        }
-
         function updateBreathingSFX() {
             // Pause breathing SFX if in battle or killed
             if (player.inCombat || player.hp <= 0) {
@@ -8908,10 +9172,10 @@ A Javascript game by <a href="https://milklounge.wang/tardquest/" target="_blank
                 return;
             }
 
-            const percentLoad = getCarryWeight() / getCarryWeightLimit();
+            const weightLevel = player.getWeightLevel();
 
             // Stop all breathing sounds if below 50%
-            if (percentLoad < 0.5) {
+            if (weightLevel === "normal") {
                 if (currentBreathing) {
                     sfx[currentBreathing].pause();
                     sfx[currentBreathing].currentTime = 0;
@@ -8920,23 +9184,8 @@ A Javascript game by <a href="https://milklounge.wang/tardquest/" target="_blank
                 return;
             }
 
-            // 80%+: Only breathe2, looped
-            if (percentLoad >= 0.8) {
-                if (currentBreathing !== "breathe2") {
-                    if (currentBreathing) {
-                        sfx[currentBreathing].pause();
-                        sfx[currentBreathing].currentTime = 0;
-                    }
-                    sfx.breathe2.loop = true;
-                    sfx.breathe2.currentTime = 0;
-                    sfx.breathe2.play();
-                    currentBreathing = "breathe2";
-                }
-                return;
-            }
-
             // 50%-80%: Only breathe1, looped
-            if (percentLoad >= 0.5) {
+            if (weightLevel === "warning") {
                 if (currentBreathing !== "breathe1") {
                     if (currentBreathing) {
                         sfx[currentBreathing].pause();
@@ -8946,6 +9195,21 @@ A Javascript game by <a href="https://milklounge.wang/tardquest/" target="_blank
                     sfx.breathe1.currentTime = 0;
                     sfx.breathe1.play();
                     currentBreathing = "breathe1";
+                }
+                return;
+            }
+
+            // 80%+: Only breathe2, looped
+            if (weightLevel === "danger") {
+                if (currentBreathing !== "breathe2") {
+                    if (currentBreathing) {
+                        sfx[currentBreathing].pause();
+                        sfx[currentBreathing].currentTime = 0;
+                    }
+                    sfx.breathe2.loop = true;
+                    sfx.breathe2.currentTime = 0;
+                    sfx.breathe2.play();
+                    currentBreathing = "breathe2";
                 }
                 return;
             }

--- a/src/game.html
+++ b/src/game.html
@@ -102,6 +102,7 @@
         }
 
         #titleScreen {
+            cursor: pointer;
             position: fixed;
             left: 0;
             top: 0;
@@ -410,6 +411,8 @@
         }
 
         #menuList {
+            display: flex;
+            flex-direction: column;
             margin-bottom: auto;
             padding-left: 1em;
             min-height: 150px;
@@ -436,6 +439,14 @@
         #menuSelectionDescription::before {
             display: block;
             text-align: center;
+        }
+
+        #menuList .cursor {
+            color: #fff;
+        }
+
+        #menuList .option {
+            cursor: pointer;
         }
 
         #menuLanding {
@@ -1109,7 +1120,7 @@
 <body>
 
 <!-- Title screen -->
-    <div id="titleScreen">
+    <div id="titleScreen" onclick="hideTitleScreen()">
         <div id="content">
             <pre class="logo">
                                                          ▄▄
@@ -6093,6 +6104,14 @@ A Javascript game by <a href="https://milklounge.wang/tardquest/" target="_blank
             display: (e) => {
                 const trigger = e.target;
                 const tooltip = trigger.querySelector("[role=tooltip]");
+                if (!tooltip) {
+                    console.warn(
+                        "Cannot display tooltip: no tooltip found",
+                        { e }
+                    );
+                    return;
+                }
+
                 const { x, y, width, height } = trigger.getBoundingClientRect();
 
                 tooltip.style.left = `${Math.floor(x)}px`;
@@ -6101,104 +6120,50 @@ A Javascript game by <a href="https://milklounge.wang/tardquest/" target="_blank
             },
             hide: (e) => {
                 const tooltip = e.target.querySelector("[role=tooltip]");
+                if (!tooltip) {
+                    console.warn(
+                        "Cannot hide tooltip: no tooltip found",
+                        { e }
+                    );
+                    return;
+                }
                 tooltip.classList.remove("active");
             },
-            refresh: () => {
-                document.querySelectorAll("[data-tooltipHtml]").forEach((trigger) => {
-                    let tooltip = document.createElement("div");
-
-                    tooltip.setAttribute("role", "tooltip");
-                    tooltip.setAttribute("inert", true);
-                    if (trigger.dataset?.tooltipposition) {
-                        tooltip.classList.add(trigger.dataset.tooltipposition);
-                    }
-                    tooltip.innerHTML = trigger.dataset.tooltiphtml;
-
-                    trigger.appendChild(tooltip);
-
-                    trigger.addEventListener("mouseenter", (e) => {
-                        clearTimeout(Tooltip.timer);
-
-                        Tooltip.timer = setTimeout(() => {
-                            Tooltip.display(e);
-                        }, Tooltip.delayTimeMs);
-                    });
-
-                    trigger.addEventListener("mouseleave", (e) => {
-                        clearTimeout(Tooltip.timer);
-                        Tooltip.hide(e);
-                    });
-                });
-            },
-        };
-
-        const Minimap = {
-            hide: () => document.getElementById('minimapContainer').classList.add('hidden'),
-            show: () => document.getElementById('minimapContainer').classList.remove('hidden'),
-            draw: () => {
-                const $minimap = document.getElementById('minimap');
-                $minimap.replaceChildren();
-
-                for (let y = 0; y < HEIGHT; y++) {
-                    for (let x = 0; x < WIDTH; x++) {
-                        let tile = '';
-                        let tileClass = '';
-                        if (x === player.x && y === player.y) {
-                            const arrow = ['↑', '→', '↓', '←'][player.dir];
-                            tile = arrow;
-                            tileClass = 'player';
-                        } else if (!seenTiles[y][x]) {
-                            tile = '?';
-                            tileClass = 'unexplored';
-                        } else {
-                            // Use a visibility function if one is available
-                            // Otherwise, assume that the tile is visible
-                            const isVisible = typeof MAP[y][x]?.isVisible !== 'function' || MAP[y][x].isVisible();
-
-                            if (isVisible) {
-                                tile = MAP[y][x]?.mapCharacter || '?';
-                                tileClass = MAP[y][x]?.type || 'unknown';
-                                tileClass = tileClass === 'mimic' ? 'treasureChest' : tileClass;
-                            } else {
-                                const emptyCell = new MapCell();
-                                tile = emptyCell.mapCharacter;
-                                tileClass = emptyCell.type;
-                            }
-                        }
-
-                        const displayName =
-                            (x === player.x && y === player.y)
-                                ? 'You ヽ(°٢° )ノ'
-                                : (seenTiles[y][x]
-                                    ? MAP[y][x].displayName
-                                    : "Unexplored"
-                                );
-
-                        const $cell = document.createElement('span');
-                        $cell.classList.add(tileClass);
-                        $cell.setAttribute(
-                            'data-tooltipHtml',
-                            `<div class="mapCellDetails">
-                                <div class="enlargedTile ${tileClass}">${tile}</div>
-                                <div class="details">
-                                    <div class="name">${displayName}</div>
-                                    <div class="coordinates">(${x}, ${y})</div>
-                                </div>
-                            </div>`
-                        );
-
-                        $cell.setAttribute('data-tooltipPosition', 'right');
-                        $cell.innerText = tile;
-                        $minimap.append($cell);
-                    }
-
-                    if (y < HEIGHT - 1) {
-                        $minimap.append(document.createElement('br'));
-                    }
+            refresh: ($element) => {
+                if (!$element.dataset.tooltiphtml) {
+                    console.warn("No tooltip data to refresh", { $element });
+                    return;
                 }
 
-                Tooltip.refresh();
-            }
+                if ($element.querySelector('div[role="tooltip"]')) {
+                    console.warn("Element already has a tooltip", { $element });
+                    return;
+                }
+
+                let tooltip = document.createElement("div");
+
+                tooltip.setAttribute("role", "tooltip");
+                tooltip.setAttribute("inert", true);
+                if ($element.dataset?.tooltipposition) {
+                    tooltip.classList.add($element.dataset.tooltipposition);
+                }
+                tooltip.innerHTML = $element.dataset.tooltiphtml;
+
+                $element.appendChild(tooltip);
+
+                $element.addEventListener("mouseenter", (e) => {
+                    clearTimeout(Tooltip.timer);
+
+                    Tooltip.timer = setTimeout(() => {
+                        Tooltip.display(e);
+                    }, Tooltip.delayTimeMs);
+                });
+
+                $element.addEventListener("mouseleave", (e) => {
+                    clearTimeout(Tooltip.timer);
+                    Tooltip.hide(e);
+                });
+            },
         };
 
         const Portrait = {
@@ -6207,7 +6172,7 @@ A Javascript game by <a href="https://milklounge.wang/tardquest/" target="_blank
             hide: () => {
                 clearTimeout(Portrait.timer);
                 document.getElementById('portraitArtOverlay').classList.add('hidden');
-                Minimap.show();
+                document.getElementById('minimapContainer').classList.remove('hidden');
             },
             show: (portraitName) => {
                 const $overlay = document.getElementById('portraitArtOverlay');
@@ -6224,7 +6189,7 @@ A Javascript game by <a href="https://milklounge.wang/tardquest/" target="_blank
                     return;
                 }
 
-                Minimap.hide();
+                document.getElementById('minimapContainer').classList.add('hidden');
 
                 clearTimeout(Portrait.timer);
                 Portrait.activeFrame = 0;
@@ -6418,7 +6383,7 @@ A Javascript game by <a href="https://milklounge.wang/tardquest/" target="_blank
                 let xPosition = entry.drawAt.x + (drawOptions.flippedX ? longestLine : 0);
                 let yPosition = entry.drawAt.y;
 
-                for (character of art) {
+                for (const character of art) {
                     if (character === "\n") {
                         xPosition = entry.drawAt.x + (drawOptions.flippedX ? longestLine : 0);
                         yPosition++;
@@ -6621,8 +6586,15 @@ A Javascript game by <a href="https://milklounge.wang/tardquest/" target="_blank
         };
 
         class MapCell {
+            static getCellId(x, y) {
+                return `map_cell_${x}_${y}`;
+            }
+
             constructor(type = "floor", options = {}) {
                 const defaults = MapCell.defaultsByType(type);
+                this.$element = options?.$element || null;
+                this.x = typeof(options?.x === "number") ? options.x : null;
+                this.y = typeof(options?.y === "number") ? options.y : null;
                 this.type = type;
                 this.displayName = options?.displayName || defaults.displayName;
                 this.mapCharacter = options?.mapCharacter || defaults.mapCharacter;
@@ -6630,7 +6602,96 @@ A Javascript game by <a href="https://milklounge.wang/tardquest/" target="_blank
                 this.onEnter = options?.onEnter || defaults.onEnter;
                 this.onTouch = options?.onTouch || defaults.onTouch;
                 this.onExplode = options?.onExplode || defaults.onExplode;
+                this.isExplored = options?.isExplores || defaults.isExplored;
                 this.isVisible = options?.isVisible || defaults.isVisible;
+                if (this.x && this.y && !this.$element) {
+                    const cellId = this.constructor.getCellId(this.x, this.y);
+                    this.$element = document.getElementById(cellId);
+                }
+
+                if (this.$element) {
+                    this.refreshElement();
+                }
+
+                const handler = {
+                    set: (target, prop, value) => {
+                        const oldVal = target[prop];
+                        if (oldVal !== value) {
+                            target[prop] = value;
+                            this.refreshElement();
+                        }
+                        return true;
+                    }
+                };
+
+                return new Proxy(this, handler);
+            }
+
+            refreshElement() {
+                if (!this.$element) {
+                    console.warn("MapCell has no element to refresh");
+                    return;
+                }
+
+                let tile = '';
+                let tileClass = '';
+                if (!this.isExplored) {
+                    tile = '?';
+                    tileClass = 'unexplored';
+                } else {
+                    // Use a visibility function if one is available
+                    // Otherwise, assume that the tile is visible
+                    const isVisible = typeof this.isVisible !== 'function' || this.isVisible();
+
+                    if (isVisible) {
+                        tile = this.mapCharacter || '?';
+                        tileClass = this.type || 'unknown';
+                        tileClass = tileClass === 'mimic' ? 'treasureChest' : tileClass;
+                    } else {
+                        const emptyCell = new MapCell();
+                        tile = emptyCell.mapCharacter;
+                        tileClass = emptyCell.type;
+                    }
+                }
+                /*
+                const displayName =
+                    (x === player.x && y === player.y)
+                        ? 'You ヽ(°٢° )ノ'
+                        : (MAP[y][x]?.isExplored
+                            ? MAP[y][x].displayName
+                            : "Unexplored"
+                        );
+                */
+                const displayName = this.isExplored
+                    ? this.displayName
+                    : "Unexplored";
+
+                this.$element.className = tileClass;
+
+                const hasCoordinates =
+                    typeof this.x === "number" &&
+                    typeof this.y === "number";
+
+                if (hasCoordinates) {
+                    this.$element.setAttribute(
+                        'data-tooltipHtml',
+                        `<div class="mapCellDetails">
+                            <div class="enlargedTile ${tileClass}">${tile}</div>
+                            <div class="details">
+                                <div class="name">${displayName}</div>
+                                <div class="coordinates">(${this.x}, ${this.y})</div>
+                            </div>
+                        </div>`
+                    );
+
+                    this.$element.setAttribute('data-tooltipPosition', 'right');
+                } else {
+                    this.$element.removeAttribute('data-tooltipHtml');
+                    this.$element.removeAttribute('data-tooltipPosition');
+                }
+
+                this.$element.innerText = tile;
+                Tooltip.refresh(this.$element);
             }
 
             static defaultsByType(type) {
@@ -6662,6 +6723,9 @@ A Javascript game by <a href="https://milklounge.wang/tardquest/" target="_blank
                  *   with a brick of C4. Always called with its own x, y
                  *   coordinates
                  *
+                 * isExplored
+                 *   When false, the cell appears as "Unexplored" on the minimap
+                 *
                  * isVisible
                  *   A function that determines if the tile is visible. If it
                  *   returns false, the tile appears as a generic floor instead
@@ -6673,6 +6737,7 @@ A Javascript game by <a href="https://milklounge.wang/tardquest/" target="_blank
                     onEnter: null,
                     onTouch: null,
                     onExplode: null,
+                    isExplored: true,
                     isVisible: null,
                 };
 
@@ -6684,7 +6749,7 @@ A Javascript game by <a href="https://milklounge.wang/tardquest/" target="_blank
                     healingTile: {
                         displayName: "Healing Tile",
                         mapCharacter: "H",
-                        onEnter: (x, y) => {
+                        onEnter: function (x, y) {
                             player.steppingOnHealingTile = true;
 
                             // Heal 30% of effective max HP
@@ -6697,31 +6762,35 @@ A Javascript game by <a href="https://milklounge.wang/tardquest/" target="_blank
                                 `</span></span>`
                             );
 
-                            MAP[y][x] = new MapCell();
+                            MAP[y][x] = new MapCell("floor", { x, y });
                         },
                     },
                     wall: {
                         displayName: "Wall",
                         mapCharacter: "#",
                         isSolid: true,
-                        onExplode: (x, y) =>
+                        onExplode: function (x, y) {
                             MAP[y][x] = new MapCell(
-                                Math.random() < 0.5 ? 'rubble1' : 'rubble2'
-                            ),
+                                Math.random() < 0.5 ? 'rubble1' : 'rubble2',
+                                { x, y, $element: this.$element }
+                            );
+                        },
                     },
                     iceWall: {
                         displayName: "Wall",
                         mapCharacter: '#',
                         isSolid: true,
-                        onExplode: (x, y) =>
+                        onExplode: function (x, y) {
                             MAP[y][x] = new MapCell(
-                                Math.random() < 0.5 ? 'rubble1' : 'rubble2'
-                            ),
+                                Math.random() < 0.5 ? 'rubble1' : 'rubble2',
+                                { x, y, $element: this.$element }
+                            );
+                        },
                     },
                     crackedFloorSlight: {
                         displayName: "Slightly-Cracked Floor",
                         mapCharacter: '✕',
-                        onEnter: (x, y) => {
+                        onEnter: function (x, y) {
                             const key = `${x},${y}`;
                             // Determine step threshold based on carry weight
                             const percent = getCarryWeight() / getCarryWeightLimit();
@@ -6734,7 +6803,10 @@ A Javascript game by <a href="https://milklounge.wang/tardquest/" target="_blank
                             if (crackedFloorSteps[key] < threshold) {
                                 // Not yet breaking, but upgrade to severe if not already
                                 if (MAP[y][x].type !== 'crackedFloorSevere') {
-                                    MAP[y][x] = new MapCell('crackedFloorSevere');
+                                    MAP[y][x] = new MapCell(
+                                        'crackedFloorSevere',
+                                        { x, y, $element: this.$element }
+                                    );
                                     updateBattleLog(
                                         '<span class="action">The floor cracks under ' +
                                         'your feet!</span>'
@@ -6749,7 +6821,7 @@ A Javascript game by <a href="https://milklounge.wang/tardquest/" target="_blank
                     crackedFloorSevere: {
                         displayName: "Severely-Cracked Floor",
                         mapCharacter: '✖',
-                        onEnter: (x, y) => {
+                        onEnter: function (x, y) {
                             const key = `${x},${y}`;
                             // Determine step threshold based on carry weight
                             const percent = getCarryWeight() / getCarryWeightLimit();
@@ -6773,34 +6845,52 @@ A Javascript game by <a href="https://milklounge.wang/tardquest/" target="_blank
                     rubble1: {
                         displayName: "Floor",
                         mapCharacter: ".",
-                        onExplode: (x, y) => MAP[y][x] = new MapCell('rubble2'),
+                        onExplode: function (x, y) {
+                            MAP[y][x] = new MapCell(
+                                'rubble2',
+                                { x, y, $element: this.$element }
+                            );
+                        },
                     },
                     rubble2: {
                         displayName: "Floor",
                         mapCharacter: ".",
-                        onExplode: (x, y) => MAP[y][x] = new MapCell('rubble1'),
+                        onExplode: function (x, y) {
+                            MAP[y][x] = new MapCell(
+                                'rubble1',
+                                { x, y, $element: this.$element },
+                            );
+                        },
                     },
                     gloryWall: {
                         displayName: "Wall",
                         mapCharacter: "#",
                         isSolid: true,
-                        onTouch: () => player.say("Uh, no thanks. I'm not THAT brave"),
-                        onExplode: (x, y) =>
+                        onTouch: function() {
+                            player.say("Uh, no thanks. I'm not THAT brave");
+                        },
+                        onExplode: function (x, y) {
                             MAP[y][x] = new MapCell(
-                                Math.random() < 0.5 ? 'rubble1' : 'rubble2'
-                            ),
+                                Math.random() < 0.5 ? 'rubble1' : 'rubble2',
+                                { x, y, $element: this.$element }
+                            );
+                        },
                     },
                     noboWall: {
                         displayName: "Wall",
                         mapCharacter: "#",
                         isSolid: true,
-                        onTouch: () => player.say(
-                            "Who's that? ... Just some nobody, I guess"
-                        ),
-                        onExplode: (x, y) =>
+                        onTouch: function () {
+                            player.say(
+                                "Who's that? ... Just some nobody, I guess"
+                            );
+                        },
+                        onExplode: function (x, y) {
                             MAP[y][x] = new MapCell(
-                                Math.random() < 0.5 ? 'rubble1' : 'rubble2'
-                            ),
+                                Math.random() < 0.5 ? 'rubble1' : 'rubble2',
+                                { x, y, $element: this.$element }
+                            );
+                        },
                     },
                     crater: {
                         displayName: "Floor",
@@ -6813,19 +6903,29 @@ A Javascript game by <a href="https://milklounge.wang/tardquest/" target="_blank
                     exit: {
                         displayName: "Exit",
                         mapCharacter: "E",
-                        onEnter: () => descend(),
+                        onEnter: function() {
+                            descend();
+                        }
                     },
                     merchant: {
                         displayName: "Merchant",
                         mapCharacter: "M",
-                        onEnter: () => menu.open('merchant'),
-                        isVisible: () =>
-                            merchant.isAlive &&
-                            merchant.isActiveOnFloor,
-                        onExplode: (x, y) => {
+                        onEnter: function() {
+                            menu.open('merchant');
+                        },
+                        isVisible: function() {
+                            return (
+                                merchant.isAlive &&
+                                merchant.isActiveOnFloor
+                            );
+                        },
+                        onExplode: function (x, y) {
                             merchant.isAlive = false;
                             merchant.isActiveOnFloor = false;
-                            MAP[y][x] = new MapCell('bloodyCrater');
+                            MAP[y][x] = new MapCell(
+                                'bloodyCrater',
+                                { x, y, $element: this.$element }
+                            );
                             playSFX('scream');
                             merchant.say('AIEEEEEEEEEEEEEE!', true);
                             updateBattleLog(
@@ -6839,15 +6939,23 @@ A Javascript game by <a href="https://milklounge.wang/tardquest/" target="_blank
                     gambler: {
                         displayName: "Gambler",
                         mapCharacter: "G",
-                        onEnter: () => menu.open('gambler'),
-                        isVisible: () =>
-                            gambler.isAlive &&
-                            gambler.isActiveOnFloor &&
-                            player.bitcoins >= gambler.playPrice,
-                        onExplode: (x, y) => {
+                        onEnter: function() {
+                            menu.open('gambler');
+                        },
+                        isVisible: function () {
+                            return (
+                                gambler.isAlive &&
+                                gambler.isActiveOnFloor &&
+                                player.bitcoins >= gambler.playPrice
+                            );
+                        },
+                        onExplode: function (x, y) {
                             gambler.isAlive = false;
                             gambler.isActiveOnFloor = false;
-                            MAP[y][x] = new MapCell('bloodyCrater');
+                            MAP[y][x] = new MapCell(
+                                'bloodyCrater',
+                                { x, y, $element: this.$element }
+                            );
 
                             // Award between 50 and 100 BTC for the slaughter. I guess that's one way to win
                             const rewardBtc = (5 + Math.round(Math.random() * 5)) * 10;
@@ -6866,15 +6974,30 @@ A Javascript game by <a href="https://milklounge.wang/tardquest/" target="_blank
                     tardspireBanner: {
                         displayName: "Floor",
                         mapCharacter: ".",
-                        onEnter: (x, y) => MAP[y][x] = new MapCell(),
-                        onExplode: (x, y) => MAP[y][x] = new MapCell(),
+                        onEnter: function (x, y) {
+                            MAP[y][x] = new MapCell(
+                                "floor",
+                                { x, y, $element: this.$element }
+                            );
+                        },
+                        onExplode: function (x, y) {
+                            MAP[y][x] = new MapCell(
+                                "floor",
+                                { x, y, $element: this.$element }
+                            );
+                        },
                     },
                     treasureChest: {
                         displayName: "Treasure Chest",
                         mapCharacter: "T",
-                        onEnter: () => menu.open("chest"),
-                        onExplode: (x, y) => {
-                            MAP[y][x] = new MapCell('crater');
+                        onEnter: function() {
+                            menu.open("chest");
+                        },
+                        onExplode: function (x, y) {
+                            MAP[y][x] = new MapCell(
+                                'crater',
+                                { x, y, $element: this.$element }
+                            );
                             updateBattleLog(
                                 '<span class="action">Gee willikers, you ' +
                                 'just destroyed a perfectly good treasure ' +
@@ -6885,9 +7008,14 @@ A Javascript game by <a href="https://milklounge.wang/tardquest/" target="_blank
                     mimic: {
                         displayName: "Treasure Chest",
                         mapCharacter: "T",
-                        onEnter: () => menu.open("chest"),
-                        onExplode: (x, y) => {
-                            MAP[y][x] = new MapCell('bloodyCrater');
+                        onEnter: function () {
+                            menu.open("chest");
+                        },
+                        onExplode: function (x, y) {
+                            MAP[y][x] = new MapCell(
+                                'bloodyCrater',
+                                { x, y, $element: this.$element }
+                            );
 
                             // Calculate scaled BTC reward
                             const baseMimic = enemies.find(e => e.id === "mimic");
@@ -6918,9 +7046,6 @@ A Javascript game by <a href="https://milklounge.wang/tardquest/" target="_blank
         const DIRECTIONS = ['N', 'E', 'S', 'W'];
         const DX = [0, 1, 0, -1];
         const DY = [-1, 0, 1, 0];
-        let seenTiles = Array.from({
-            length: HEIGHT
-        }, () => Array(WIDTH).fill(false));
         let lastFloorBoostNotice = 0;
 
         const baseStats = {
@@ -7530,7 +7655,7 @@ A Javascript game by <a href="https://milklounge.wang/tardquest/" target="_blank
                         (y !== player.y && x !== player.x);
 
                     if (isEmptySpace) {
-                        MAP[y][x] = new MapCell('merchant');
+                        MAP[y][x] = new MapCell('merchant', { x, y });
                         return;
                     }
                 } while (attempts++ < 1000);
@@ -7641,7 +7766,7 @@ A Javascript game by <a href="https://milklounge.wang/tardquest/" target="_blank
                         !isMerchantSpace;
 
                     if (isEmptySpace) {
-                        MAP[y][x] = new MapCell('gambler');
+                        MAP[y][x] = new MapCell('gambler', { x, y });
                         return;
                     }
                 } while (attempts++ < 1000);
@@ -7906,7 +8031,7 @@ A Javascript game by <a href="https://milklounge.wang/tardquest/" target="_blank
                         return;
                     }
                     playSFX('torch');
-                    seenTiles = seenTiles.map((col) => col.map(() => true));
+                    MAP.forEach((mapY) => columns.forEach((mapY) => cell.isExplored = true));
                     updateBattleLog("Lo, the way has been made clear!");
                     animTorchStart();
                     render();
@@ -7931,7 +8056,10 @@ A Javascript game by <a href="https://milklounge.wang/tardquest/" target="_blank
                                 const nx = player.x + DX[player.dir];
                                 const ny = player.y + DY[player.dir];
                                 if (['floor', 'rubble1', 'rubble2'].includes(MAP[ny]?.[nx]?.type)) {
-                                    MAP[ny][nx] = new MapCell('bloodyCrater');
+                                    MAP[ny][nx] = new MapCell(
+                                        'bloodyCrater',
+                                        { x: nx, y: ny }
+                                    );
                                 }
                             }
                             endOfPlayerTurn();
@@ -7972,7 +8100,7 @@ A Javascript game by <a href="https://milklounge.wang/tardquest/" target="_blank
                                         if (isVisible) {
                                             MAP[y][x]?.onExplode?.(x, y);
                                         }
-                                        seenTiles[y][x] = true;
+                                        MAP[y][x].isExplored = true;
                                     }
                                 }
                             }
@@ -8321,8 +8449,8 @@ A Javascript game by <a href="https://milklounge.wang/tardquest/" target="_blank
         function revealMapSpot(x, y, radius) {
             for (let py=y-radius; py<=y+radius; py++) {
                 for (let px=x-radius; px<=x+radius; px++) {
-                    if (typeof MAP[py]?.[px] !== 'undefined') {
-                        seenTiles[py][px] = true;
+                    if (typeof MAP[py]?.[px] !== "undefined") {
+                        MAP[py][px].isExplored = true;
                     }
                 }
             }
@@ -8449,8 +8577,10 @@ A Javascript game by <a href="https://milklounge.wang/tardquest/" target="_blank
             for (let y = 0; y < HEIGHT; y++) {
                 MAP[y] = [];
                 for (let x = 0; x < WIDTH; x++) {
-                    MAP[y][x] = new MapCell('wall');
-                    seenTiles[y][x] = false;
+                    MAP[y][x] = new MapCell(
+                        'wall',
+                        { x, y, isExplored: false }
+                    );
                 }
             }
 
@@ -8462,15 +8592,26 @@ A Javascript game by <a href="https://milklounge.wang/tardquest/" target="_blank
             } while (stack === null);
 
             for (let i in stack) {
-                MAP[stack[i].y][stack[i].x] = new MapCell();
+                MAP[stack[i].y][stack[i].x] = new MapCell(
+                    'floor',
+                    { x: stack[i].x, y: stack[i].y, isExplored: false }
+                );
             }
 
             for (let i = 0; i < 10; i++) {
                 dissolveMap();
             }
 
-            MAP[player.y][player.x] = new MapCell();
-            MAP[exit.y][exit.x] = new MapCell('exit');
+            MAP[player.y][player.x] = new MapCell('floor', {
+                x: player.x,
+                y: player.y,
+            });
+
+            MAP[exit.y][exit.x] = new MapCell('exit', {
+                x: exit.x,
+                y: exit.y,
+                isExplored: false,
+            });
 
             // 100% chance to spawn merchant on floor 1
             if (floor === 1) {
@@ -8496,6 +8637,22 @@ A Javascript game by <a href="https://milklounge.wang/tardquest/" target="_blank
             spawnTreasureChests();
             spawnHealingTiles();
             spawnCrackedFloors();
+
+            // Generate minimap
+            const $minimap = document.getElementById('minimap');
+            $minimap.replaceChildren();
+
+            for (let y = 0; y < HEIGHT; y++) {
+                for (let x = 0; x < WIDTH; x++) {
+                    const $cell = document.createElement('span');
+                    $cell.id = MapCell.getCellId(x, y);
+                    $minimap.append($cell);
+                    // Track the minimap element in the MAP
+                    MAP[y][x].$element = $cell;
+                }
+
+                $minimap.append(document.createElement('br'));
+            }
 
             document.getElementById('minimapHeader').innerText =
                 `Dungeon Floor ${floor}`;
@@ -8526,19 +8683,31 @@ A Javascript game by <a href="https://milklounge.wang/tardquest/" target="_blank
         function placeWelcomeBanner() {
             if (MAP[player.y - 1][player.x]?.type === 'floor') {
                 // North of player
-                MAP[player.y - 1][player.x] = new MapCell('tardspireBanner');
+                MAP[player.y - 1][player.x] = new MapCell(
+                    'tardspireBanner',
+                    { x: player.x, y: player.y - 1 },
+                );
                 player.dir = DIRECTIONS.indexOf('N');
             } else if (MAP[player.y + 1][player.x]?.type === 'floor') {
                 // South of player
-                MAP[player.y + 1][player.x] = new MapCell('tardspireBanner');
+                MAP[player.y + 1][player.x] = new MapCell(
+                    'tardspireBanner',
+                    { x: player.x, y: player.y + 1 }
+                );
                 player.dir = DIRECTIONS.indexOf('S');
             } else if (MAP[player.y][player.x - 1]?.type === 'floor') {
                 // West of player
-                MAP[player.y][player.x - 1] = new MapCell('tardspireBanner');
+                MAP[player.y][player.x - 1] = new MapCell(
+                    'tardspireBanner',
+                    { x: player.x - 1, y: player.y }
+                );
                 player.dir = DIRECTIONS.indexOf('W');
             } else if (MAP[player.y][player.x + 1]?.type === 'floor') {
                 // East of player
-                MAP[player.y][player.x + 1] = new MapCell('tardspireBanner');
+                MAP[player.y][player.x + 1] = new MapCell(
+                    'tardspireBanner',
+                    { x: player.x + 1, y: player.y }
+                );
                 player.dir = DIRECTIONS.indexOf('E');
             }
 
@@ -8547,7 +8716,7 @@ A Javascript game by <a href="https://milklounge.wang/tardquest/" target="_blank
             const gy = player.y - DY[player.dir];
 
             if (MAP[gy][gx]?.type === 'wall') {
-                MAP[gy][gx] = new MapCell('gloryWall');
+                MAP[gy][gx] = new MapCell('gloryWall', { x: gx, y: gy });
             }
         }
 
@@ -8555,7 +8724,10 @@ A Javascript game by <a href="https://milklounge.wang/tardquest/" target="_blank
             const dissolvePoints = getMapDissolvePoints();
             const index = Math.floor(Math.random() * dissolvePoints.length);
             const dissolvePoint = dissolvePoints[index];
-            MAP[dissolvePoint.y][dissolvePoint.x] = new MapCell('noboWall');
+            MAP[dissolvePoint.y][dissolvePoint.x] = new MapCell(
+                'noboWall',
+                { x: dissolvePoint.x, y: dissolvePoint.y }
+            );
         }
 
         function spawnTreasureChests() {
@@ -8573,7 +8745,10 @@ A Javascript game by <a href="https://milklounge.wang/tardquest/" target="_blank
 
                     if (isEmptySpace) {
                         const isMimic = Math.random() < 0.2; // 20% chance for mimic
-                        MAP[y][x] = new MapCell(isMimic ? 'mimic' : 'treasureChest');
+                        MAP[y][x] = new MapCell(
+                            isMimic ? 'mimic' : 'treasureChest',
+                            { x, y }
+                        );
                         break;
                     }
                 }
@@ -8594,7 +8769,10 @@ A Javascript game by <a href="https://milklounge.wang/tardquest/" target="_blank
                         (y !== player.y || x !== player.x);
 
                     if (isEmptySpace) {
-                        MAP[y][x] = new MapCell('healingTile'); // Place a healing tile
+                        MAP[y][x] = new MapCell(
+                            'healingTile',
+                            { x, y }
+                        );
                         break;
                     }
                 }
@@ -8615,7 +8793,10 @@ A Javascript game by <a href="https://milklounge.wang/tardquest/" target="_blank
                         (y !== player.y || x !== player.x);
 
                     if (isEmptySpace) {
-                        MAP[y][x] = new MapCell('crackedFloorSlight');
+                        MAP[y][x] = new MapCell(
+                            'crackedFloorSlight',
+                            { x, y }
+                        );
                         break;
                     }
                 }
@@ -8735,7 +8916,10 @@ A Javascript game by <a href="https://milklounge.wang/tardquest/" target="_blank
             for (let i = 0; i < totalPointsToDissolve; i++) {
                 const index = Math.floor(Math.random() * dissolvePoints.length);
                 const dissolvePoint = dissolvePoints[index];
-                MAP[dissolvePoint.y][dissolvePoint.x] = new MapCell();
+                MAP[dissolvePoint.y][dissolvePoint.x] = new MapCell(
+                    'floor',
+                    { x: dissolvePoint.x, y: dissolvePoint.y }
+                );
                 dissolvePoints = dissolvePoints.splice(index, 1);
             }
         }
@@ -8776,7 +8960,6 @@ A Javascript game by <a href="https://milklounge.wang/tardquest/" target="_blank
 
         function render() {
             updateSeenTiles();
-            Minimap.draw();
             updateBreathingSFX();
 
             // @TODO: Keep this out of render()
@@ -8908,8 +9091,7 @@ A Javascript game by <a href="https://milklounge.wang/tardquest/" target="_blank
             const $titleScreen = document.getElementById('titleScreen');
             if (
                 window._inputBlocked &&
-                $titleScreen &&
-                $titleScreen.style.display !== 'none' &&
+                $titleScreen?.style?.display !== 'none' &&
                 (e.key === 'Enter' || e.key === ' ')
             ) {
                 return;
@@ -8924,7 +9106,7 @@ A Javascript game by <a href="https://milklounge.wang/tardquest/" target="_blank
 
         function setTorchOverlayVisibility() {
             // Hide torch in combat, resume after battle
-            $torch = document.getElementById('animTorch');
+            const $torch = document.getElementById('animTorch');
             player.isHoldingTorch && !player.inCombat
                 ? $torch.classList.add('onscreen')
                 : $torch.classList.remove('onscreen');
@@ -9456,96 +9638,10 @@ A Javascript game by <a href="https://milklounge.wang/tardquest/" target="_blank
                 updateBattleLog("You don't have that item!");
                 return;
             }
-            // Item effects + battle log msgs based on item name found in data/items.json
-            switch (itemName) {
-                case "canOfHamms":
-                    player.heal(5);
-                    updateBattleLog("You chug the can, filling your mouth with the flavor of boiled socks. +5 HP");
-                    break;
-                case "cupOfLean":
-                    player.heal(20);
-                    updateBattleLog("Your stomach feels nauseous, but your head feels great! +20 HP");
-                    break;
-                case "glassOfToiletWater":
-                    player.heal(50);
-                    updateBattleLog("Sickeningly delicious...? You question your current state of mind for a moment. +50 HP");
-                    break;
-                case "alaskaRaisins":
-                    player.heal(70);
-                    playSFX('raisins');
-                    updateBattleLog("The Alaska Raisins sing a lovely song about how epic igloos are as you pop them into your mouth one by one. You can still hear them singing in your stomach... +70 HP");
-                    break;
-                case "dowsingRod":
-                    for (let y = 0; y < MAP.length; y++) {
-                        for (let x = 0; x < MAP[y].length; x++) {
-                            if (MAP[y][x]?.type === 'exit') {
-                                revealMapSpot(x, y, 1);
-                                updateBattleLog("The exit has been revealed!");
-                                render();
-                                return;
-                            }
-                        }
-                    }
-                    break;
-                case "torch":
-                    if (player.isHoldingTorch) {
-                        updateBattleLog("Uh, do you not SEE the torch that you are already holding?");
-                        return;
-                    }
-                    playSFX('torch');
-                    seenTiles = seenTiles.map((col) => col.map(() => true));
-                    updateBattleLog("Lo, the way has been made clear!");
-                    animTorchStart();
-                    render();
-                    break;
-                case "brickOfC4":
-                    setTimeout(() => playSFX('explosion'), 50);
-                    explosionAnimation(() => {
-                        if (player.inCombat) {
-                            const dmg = Math.max(20, Math.round(Math.random() * 10) * 5);
-                            currentEnemy.hp -= dmg;
-                            updateBattleLog(`You exploded the shit out of <span class="action">${currentEnemy.name}</span> for <span class="HP">${dmg} HP</span>!!!`);
-                            if (currentEnemy.hp <= 0) {
-                                playSFX('scream');
-                                const nx = player.x + DX[player.dir];
-                                const ny = player.y + DY[player.dir];
-                                if (['floor', 'rubble1', 'rubble2'].includes(MAP[ny]?.[nx]?.type)) {
-                                    MAP[ny][nx] = new MapCell('bloodyCrater');
-                                }
-                            }
-                            endOfPlayerTurn();
-                        } else {
-                            let xMin = player.x, xMax = player.x,
-                                yMin = player.y, yMax = player.y;
-                            switch (DIRECTIONS[player.dir]) {
-                                case 'N': xMin--; xMax++; yMin -= 3; break;
-                                case 'E': yMin--; yMax++; xMax += 3; break;
-                                case 'S': xMin--; xMax++; yMax += 3; break;
-                                case 'W': yMin--; yMax++; xMin -= 3; break;
-                            }
-                            for (let y = yMin; y <= yMax; y++) {
-                                for (let x = xMin; x <= xMax; x++) {
-                                    if (MAP[y]?.[x]) {
-                                        const isVisible = typeof MAP[y][x].isVisible !== 'function' || MAP[y][x].isVisible();
-                                        if (isVisible) {
-                                            MAP[y][x]?.onExplode?.(x, y);
-                                        }
-                                        seenTiles[y][x] = true;
-                                    }
-                                }
-                            }
-                            updateBattleLog('<span class="action">KABOOM!</span> The dungeon walls crumble like charred toast!');
-                            render();
-                        }
-                    });
-                    break;
-                case "tromBone":
-                    playSFX('tromBone');
-                    updateBattleLog("You play a trom-BONE. It sounds like a trombone, but somehow... bonier. Not very strong bone though. It shatters in your hands after you play your song. It was good while it lasted.");
-                    break;
-                default:
-                    updateBattleLog("You used the item, but nothing happened.");
-            }
+
+            typeof items[itemName]?.use === "function"
+                ? items[itemName].use()
+                : updateBattleLog("You used the item, but nothing happened.");
         
             player.inventory[itemName]--;
             if (player.inventory[itemName] <= 0) {
@@ -9563,7 +9659,7 @@ A Javascript game by <a href="https://milklounge.wang/tardquest/" target="_blank
                     if (coordsInBounds(nx, ny) && MAP[ny][nx]?.type === 'floor') {
                         merchant.isAlive = true;
                         merchant.isActiveOnFloor = true;
-                        MAP[ny][nx] = new MapCell('merchant');
+                        MAP[ny][nx] = new MapCell('merchant', { x: nx, y: ny });
                         merchant.set();
                         updateBattleLog('<span class="merchant">CHEAT: Merchant spawned</span>');
                         found = true;
@@ -9585,7 +9681,7 @@ A Javascript game by <a href="https://milklounge.wang/tardquest/" target="_blank
                         gambler.isActiveOnFloor = true;
                         player.bitcoins = Math.max(player.bitcoins, gambler.playPrice);
                         player.refreshBitcoins();
-                        MAP[ny][nx] = new MapCell('gambler');
+                        MAP[ny][nx] = new MapCell('gambler', { x: nx, y: ny });
                         updateBattleLog('<span class="gambler">CHEAT: Gambler spawned</span>');
                         found = true;
                         break;
@@ -9712,7 +9808,7 @@ A Javascript game by <a href="https://milklounge.wang/tardquest/" target="_blank
                         merchant.isAlive = true;
                         merchant.isActiveOnFloor = true;
                         merchant.setWares(true);
-                        MAP[ny][nx] = new MapCell('merchant');
+                        MAP[ny][nx] = new MapCell('merchant', { x: nx, y: ny });
                         merchantSpawned = true;
                         break;
                     }
@@ -9737,7 +9833,10 @@ A Javascript game by <a href="https://milklounge.wang/tardquest/" target="_blank
                         ) {
                             gambler.isAlive = true;
                             gambler.isActiveOnFloor = true;
-                            MAP[gy][gx] = new MapCell('gambler');
+                            MAP[gy][gx] = new MapCell(
+                                'gambler',
+                                { x: gx, y: gy }
+                            );
                             gamblerSpawned = true;
                             break;
                         }
@@ -10007,7 +10106,12 @@ A Javascript game by <a href="https://milklounge.wang/tardquest/" target="_blank
             if (MAP[player.y][player.x]?.type === 'mimic') {
                 // Mimic detected, start a battle
                 playSFX('scream');
-                MAP[player.y][player.x] = new MapCell(); // Remove the mimic from the map
+
+                // Remove the mimic from the map
+                MAP[player.y][player.x] = new MapCell(
+                    "floor",
+                    { x: player.y, y: player.y }
+                );
 
                 // Spawn mimic and apply scaling
                 const baseMimic = enemies.find(e => e.id === "mimic");
@@ -10055,7 +10159,11 @@ A Javascript game by <a href="https://milklounge.wang/tardquest/" target="_blank
                     updateBattleLog(`You found <span class="friendly">${rings[ringId].name}</span> in the chest!`);
                 }
 
-                MAP[player.y][player.x] = new MapCell(); // Remove the chest from the map
+                // Remove the chest from the map
+                MAP[player.y][player.x] = new MapCell(
+                    "floor",
+                    { x: player.x, y: player.y }
+                );
             }
 
             render();
@@ -10187,7 +10295,6 @@ A Javascript game by <a href="https://milklounge.wang/tardquest/" target="_blank
 
         generateMap();
         updateSeenTiles();
-        Minimap.draw();
         playRandomExplorationMusic();
         render();
 
@@ -10242,6 +10349,9 @@ A Javascript game by <a href="https://milklounge.wang/tardquest/" target="_blank
                 document.getElementById('menu').classList.add('hidden');
                 document.getElementById('game').classList.remove('hidden');
             },
+            highlightOption: (index) => {
+                menu.selectionIndex = index;
+            },
             render: () => {
                 let menuHtml = "";
                 const activeMenu = menu.getActiveMenu();
@@ -10274,7 +10384,11 @@ A Javascript game by <a href="https://milklounge.wang/tardquest/" target="_blank
                 paginatedOptions.forEach((option, index) => {
                     const isSelectedLine = index === menu.selectionIndex;
                     const cursor = isSelectedLine ? "▶ " : "  ";
-                    const spanHtml = option.className ? `<span class="${option.className}">` : '<span>';
+                    const spanHtml = "<span " +
+                        `class="option${option.className ? ` ${option.className}` : ""}"` +
+                        `onmouseover="menu.highlightOption(${index}); menu.render();" ` +
+                        `onclick="menu.select(${index});"` +
+                    ">";
                     const trailText = option.trailText ? `${option.trailText}` : '';
 
                     const maxLineLength = 56; // Max "." trail width
@@ -10282,8 +10396,9 @@ A Javascript game by <a href="https://milklounge.wang/tardquest/" target="_blank
                         ? '.'.repeat(Math.max(0, maxLineLength - option.displayText.length - trailText.length - 4))
                         : '';
 
-                    menuHtml += `${cursor}${spanHtml}${option.displayText}${dots}${trailText}</span>\n`;
-
+                    menuHtml +=
+                        `${spanHtml}<span class="cursor">${cursor}</span>` +
+                        `${option.displayText}${dots}${trailText}</span>`;
 
                     if (isSelectedLine) {
                         document.getElementById('menuSelectionDescription').textContent = option.description;
@@ -10299,11 +10414,13 @@ A Javascript game by <a href="https://milklounge.wang/tardquest/" target="_blank
                     $escapeMessage.classList.remove("hidden");
                 }
             },
+            getNumberOfItemsPerPage: () =>
+                menu.breadcrumbs.at(-1)?.menuName === "statAllocation" ? 12 : 8,
             handleInput: (key) => {
                 if (animationActive) return;
                 const activeMenu = menu.getActiveMenu();
                 const options = activeMenu.getOptions();
-                const itemsPerPage = menu.breadcrumbs.at(-1)?.menuName === "statAllocation" ? 12 : 8; // Number of items per page
+                const itemsPerPage = menu.getNumberOfItemsPerPage();
                 const totalPages = Math.ceil(options.length / itemsPerPage);
                 const itemsOnCurrentPage = (menu.currentPage + 1) >= totalPages
                     ? ((options.length % itemsPerPage) || itemsPerPage)
@@ -10311,12 +10428,7 @@ A Javascript game by <a href="https://milklounge.wang/tardquest/" target="_blank
 
                 switch (key) {
                     case 'escape':
-                        if (activeMenu.escapeDisabled) {
-                            break;
-                        }
-
-                        menu.close();
-                        playSFX('uiCancel');
+                        menu.goToPreviousMenu();
                         break;
                     case 'w':
                     case 'arrowup':
@@ -10351,22 +10463,36 @@ A Javascript game by <a href="https://milklounge.wang/tardquest/" target="_blank
                     case ' ':
                     case 'e':
                     case 'enter': {
-                        const selectedOptionId = options[menu.currentPage * itemsPerPage + menu.selectionIndex]?.id;
-                        if (selectedOptionId === '_back') {
-                            menu.close();
-                            playSFX('uiCancel');
-                        } else if (selectedOptionId === '_exitAll') {
-                            menu.closeAll();
-                            playSFX('uiCancel');
-                        } else {
-                            activeMenu.select(selectedOptionId);
-                            playSFX('uiSelect');
-                        }
+                        menu.select(menu.selectionIndex);
                         break;
                     }
                 }
 
                 menu.render();
+            },
+            goToPreviousMenu: () => {
+                if (menu.getActiveMenu()?.escapeDisabled) {
+                    return;
+                }
+
+                menu.close();
+                playSFX('uiCancel');
+            },
+            select: (index) => {
+                const activeMenu = menu.getActiveMenu();
+                const selectedOptionId =
+                    activeMenu.getOptions()?.
+                        [menu.currentPage * menu.getNumberOfItemsPerPage() + index]?.id;
+                if (selectedOptionId === '_back') {
+                    menu.close();
+                    playSFX('uiCancel');
+                } else if (selectedOptionId === '_exitAll') {
+                    menu.closeAll();
+                    playSFX('uiCancel');
+                } else {
+                    activeMenu?.select(selectedOptionId);
+                    playSFX('uiSelect');
+                }
             },
             menus: {
                 gameSettings: {
@@ -11140,7 +11266,11 @@ A Javascript game by <a href="https://milklounge.wang/tardquest/" target="_blank
                         gambler.isActiveOnFloor = false;
                         const gamblerPosition = gambler.location();
                         if (gamblerPosition) {
-                            MAP[gamblerPosition.y][gamblerPosition.x] = new MapCell();
+                            MAP[gamblerPosition.y][gamblerPosition.x] =
+                                new MapCell(
+                                    "floor",
+                                    { x: gamblerPosition.x, y: gamblerPosition.y }
+                                );
                         }
                         Portrait.hide();
                     },

--- a/src/game.html
+++ b/src/game.html
@@ -1,5 +1,8 @@
 <!DOCTYPE html>
-<html lang="en"><head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<html lang="en">
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>TARDQUEST</title>
     <style>
         /* ===== Scrollbar CSS ===== */
@@ -41,6 +44,7 @@
             display: flex;
             box-sizing: content-box;
             user-select: none;
+            -webkit-user-select: none;
             overflow: hidden;
         }
 
@@ -115,6 +119,7 @@
             font-size: 15px;
             white-space: pre;
             user-select: none;
+            -webkit-user-select: none;
             padding: 5px;
         }
         #titleScreen .content{
@@ -344,10 +349,11 @@
         }
 
         #viewport #mouseControl {
-            position: relative;
+            position: absolute;
             top: 0;
-            width: 100%;
-            height: 100%;
+            left: 0;
+            right: 0;
+            bottom: 0;
         }
 
         #mouseControl * {
@@ -399,67 +405,64 @@
             cursor: url(assets/cursors/attack.cur), crosshair;
         }
 
+        /** Menu Styles **/
         #menu:not(.hidden) {
-            width: 100%;
-            height: 100%;
+            height: 315px;
+            width: 360px;
+            flex-grow: 1;
+            white-space: pre-wrap;
             display: flex;
             flex-direction: column;
             gap: 10px;
+            margin: 4px;
             padding-bottom: 10px;
-            background-color: #000;
             z-index: 9;
         }
 
-        #menuList {
+        #menu .landing {
             display: flex;
             flex-direction: column;
+        }
+
+        #menu .title {
+            margin: 0 auto 1em;
+            text-transform: uppercase;
+            letter-spacing: 1ch;
+        }
+
+        #menu .list {
+            display: flex;
+            flex-direction: column;
+            flex-grow: 2;
             margin-bottom: auto;
             padding-left: 1em;
             min-height: 150px;
             z-index: 9;
         }
-        #pageNum {
-            text-align: right;
-            margin-right: 14px;
-            color: #ccc;
-        }
 
-        #menuList,
-        #menuSelectionDescription {
-            flex-grow: 1;
-            white-space: pre-wrap;
-        }
-
-        #menuLanding,
-        #menuSelectionDescription {
-            padding: 0 1em;
-        }
-
-        #menuList::before,
-        #menuSelectionDescription::before {
-            display: block;
-            text-align: center;
-        }
-
-        #menuList .cursor {
-            color: #fff;
-        }
-
-        #menuList .option {
+        #menu .option {
             cursor: pointer;
+            user-select: none;
+            -webkit-user-select: none;
         }
 
-        #menuLanding {
-            display: flex;
-            flex-direction: column;
-            white-space: pre-wrap;
-            min-height: 8em;
+        #menu .option:not(.selected)::before {
+            content: "  ";
         }
 
-        #menuLanding > .title {
-            margin: 0 auto 1em;
-            letter-spacing: 1ch;
+        #menu .option.selected::before {
+            content: "▶ ";
         }
+
+        #menu .selectionDescription {
+            flex-grow: 1;
+        }
+
+        #menu .escapeMessage {
+            position: absolute;
+            bottom: 0;
+        }
+        /** End of Menu Styles **/
 
         #animation:not(.hidden) {
             white-space: pre;
@@ -561,6 +564,26 @@
             word-wrap: break-word;
             white-space: pre-wrap;
             overflow-y: scroll;
+        }
+
+        #battleLog > * {
+            filter: brightness(.5) saturate(.5);
+        }
+
+        #battleLog > :nth-child(1) {
+            filter: brightness(1) saturate(1);
+        }
+
+        #battleLog > :nth-child(2) {
+            filter: brightness(.8) saturate(.8);
+        }
+
+        #battleLog > :nth-child(3) {
+            filter: brightness(.7) saturate(.7);
+        }
+
+        #battleLog > :nth-child(4) {
+            filter: brightness(.6) saturate(.6);
         }
 
         #minimap,
@@ -680,13 +703,13 @@
         #topLeft    { grid-area: topLeft; }
         #stats      { grid-area: stats; }
         #controls   { grid-area: controls; }
-        #viewport   { grid-area: viewport; position: relative; overflow: hidden; }
+        #viewport   { grid-area: viewport; }
         #party      { grid-area: party; }
         #inventory  { grid-area: inventory; }
 
-        #viewport > .ui-header {
+        #viewport {
             position: relative;
-            z-index: 2;
+            overflow: hidden;
         }
 
         #infoContainer {
@@ -1115,6 +1138,27 @@
         .mapCellDetails .details .name {
             font-size: 18px;
         }
+
+        @keyframes letsGo {
+            0%      { transform: scaleX(1) translateY(2px); }
+            24.9%   { transform: scaleX(1) translateY(2px); }
+
+            25%     { transform: scaleX(1) translateY(-2px); }
+            49.9%   { transform: scaleX(1) translateY(-2px); }
+
+            50%     { transform: scaleX(-1) translateY(2px); }
+            74.9%   { transform: scaleX(-1) translateY(2px); }
+
+            75%     { transform: scaleX(-1) translateY(-2px); }
+            99.9%   { transform: scaleX(-1) translateY(-2px); }
+
+            100%    { transform: scaleX(1) translateY(2px); }
+        }
+
+        .player.lets-go {
+            display: inline-block;
+            animation: letsGo .8s linear infinite;
+        }
     </style>
 </head>
 <body>
@@ -1292,12 +1336,7 @@ A Javascript game by <a href="https://milklounge.wang/tardquest/" target="_blank
             <div id="game" class="render"></div>
             <div id="animation" class="hidden"></div>
             <div id="animTorch" class="offscreen"></div>
-            <div id="menu" class="hidden">
-                <div id="menuLanding"></div>
-                <div id="menuList"></div>
-                <div id="menuSelectionDescription"></div>
-                <div id="escapeMessage" class="alignRight">Press Escape to go back</div>
-            </div>
+            <div id="menu"></div>
             <div id="mouseControl">
                 <div class="navigation">
                     <div class="forward" onclick="move('forward')"></div>
@@ -1314,7 +1353,10 @@ A Javascript game by <a href="https://milklounge.wang/tardquest/" target="_blank
             </div>
         </div>
         <div id="party">
-            <div class="ui-header">Party</div>
+            <div class="ui-header">
+                Party
+                (<span id="totalPartyMembers">0</span>/<span id="maxPartyMembers">3</span>)
+            </div>
             <div id="partyMembers"></div>
         </div>
         <div id="inventory">
@@ -1323,7 +1365,10 @@ A Javascript game by <a href="https://milklounge.wang/tardquest/" target="_blank
     </div>
 
     <script src="scripts/progress-bar.js"></script>
+    <script src="scripts/Map.js"></script>
+    <script src="scripts/Menu.js"></script>
     <script src="scripts/sam.js"></script>
+    <script src="scripts/Tooltip.js"></script>
     <script src="data/portraits.js"></script>
     <script src="data/enemyart.js"></script>
     <script>
@@ -6098,74 +6143,6 @@ A Javascript game by <a href="https://milklounge.wang/tardquest/" target="_blank
             },
         };
 
-        const Tooltip = {
-            delayTimeMs: 300,
-            timer: null,
-            display: (e) => {
-                const trigger = e.target;
-                const tooltip = trigger.querySelector("[role=tooltip]");
-                if (!tooltip) {
-                    console.warn(
-                        "Cannot display tooltip: no tooltip found",
-                        { e }
-                    );
-                    return;
-                }
-
-                const { x, y, width, height } = trigger.getBoundingClientRect();
-
-                tooltip.style.left = `${Math.floor(x)}px`;
-                tooltip.style.top = `${Math.floor(y)}px`;
-                tooltip.classList.add("active");
-            },
-            hide: (e) => {
-                const tooltip = e.target.querySelector("[role=tooltip]");
-                if (!tooltip) {
-                    console.warn(
-                        "Cannot hide tooltip: no tooltip found",
-                        { e }
-                    );
-                    return;
-                }
-                tooltip.classList.remove("active");
-            },
-            refresh: ($element) => {
-                if (!$element.dataset.tooltiphtml) {
-                    console.warn("No tooltip data to refresh", { $element });
-                    return;
-                }
-
-                if ($element.querySelector('div[role="tooltip"]')) {
-                    console.warn("Element already has a tooltip", { $element });
-                    return;
-                }
-
-                let tooltip = document.createElement("div");
-
-                tooltip.setAttribute("role", "tooltip");
-                tooltip.setAttribute("inert", true);
-                if ($element.dataset?.tooltipposition) {
-                    tooltip.classList.add($element.dataset.tooltipposition);
-                }
-                tooltip.innerHTML = $element.dataset.tooltiphtml;
-
-                $element.appendChild(tooltip);
-
-                $element.addEventListener("mouseenter", (e) => {
-                    clearTimeout(Tooltip.timer);
-
-                    Tooltip.timer = setTimeout(() => {
-                        Tooltip.display(e);
-                    }, Tooltip.delayTimeMs);
-                });
-
-                $element.addEventListener("mouseleave", (e) => {
-                    clearTimeout(Tooltip.timer);
-                    Tooltip.hide(e);
-                });
-            },
-        };
-
         const Portrait = {
             activeFrame: 0,
             timer: null,
@@ -6344,7 +6321,7 @@ A Javascript game by <a href="https://milklounge.wang/tardquest/" target="_blank
                         const lateralOffset = offset * dir.flip;
                         const tx = x + dir.dx * depth + dir.lateral.dx * lateralOffset;
                         const ty = y + dir.dy * depth + dir.lateral.dy * lateralOffset;
-                        row.push(MAP[ty]?.[tx] ?? null);
+                        row.push(MAP.getCell(tx, ty));
                     }
 
                     grid.push(row);
@@ -6550,7 +6527,7 @@ A Javascript game by <a href="https://milklounge.wang/tardquest/" target="_blank
                     const $mouseControl = document.getElementById("mouseControl");
                     const frontX = player.x + DX[player.dir];
                     const frontY = player.y + DY[player.dir];
-                    const cellInFrontOfPlayer = MAP[frontY]?.[frontX];
+                    const cellInFrontOfPlayer = MAP.getCell(frontX, frontY);
                     const touchEnabled =
                         typeof cellInFrontOfPlayer?.onTouch === "function";
                     const moveForwardEnabled =
@@ -6563,481 +6540,27 @@ A Javascript game by <a href="https://milklounge.wang/tardquest/" target="_blank
 
                     const leftX = player.x + DX[(player.dir + 3) % 4];
                     const leftY = player.y + DY[(player.dir + 3) % 4];
-                    const cellLeftOfPlayer = MAP[leftY]?.[leftX];
+                    const cellLeftOfPlayer = MAP.getCell(leftX, leftY);
                     const strafeLeftEnabled = cellLeftOfPlayer?.isSolid === false;
                     $mouseControl.querySelector(".strafe-left")?.classList
                         .toggle("hidden", !strafeLeftEnabled);
 
                     const rightX = player.x + DX[(player.dir + 1) % 4];
                     const rightY = player.y + DY[(player.dir + 1) % 4];
-                    const cellRightOfPlayer = MAP[rightY]?.[rightX];
+                    const cellRightOfPlayer = MAP.getCell(rightX, rightY);
                     const strafeRightEnabled = cellRightOfPlayer?.isSolid === false;
                     $mouseControl.querySelector(".strafe-right")?.classList
                         .toggle("hidden", !strafeRightEnabled);
 
                     const backX = player.x - DX[player.dir];
                     const backY = player.y - DY[player.dir];
-                    const cellBehindPlayer = MAP[backY]?.[backX];
+                    const cellBehindPlayer = MAP.getCell(backX, backY);
                     const moveBackwardEnabled = cellBehindPlayer?.isSolid === false;
                     $mouseControl.querySelector(".backward")?.classList
                         .toggle("hidden", !moveBackwardEnabled);
                 }
             },
         };
-
-        class MapCell {
-            static getCellId(x, y) {
-                return `map_cell_${x}_${y}`;
-            }
-
-            constructor(type = "floor", options = {}) {
-                const defaults = MapCell.defaultsByType(type);
-                this.$element = options?.$element || null;
-                this.x = typeof(options?.x === "number") ? options.x : null;
-                this.y = typeof(options?.y === "number") ? options.y : null;
-                this.type = type;
-                this.displayName = options?.displayName || defaults.displayName;
-                this.mapCharacter = options?.mapCharacter || defaults.mapCharacter;
-                this.isSolid = options?.isSolid || defaults.isSolid;
-                this.onEnter = options?.onEnter || defaults.onEnter;
-                this.onTouch = options?.onTouch || defaults.onTouch;
-                this.onExplode = options?.onExplode || defaults.onExplode;
-                this.isExplored = options?.isExplores || defaults.isExplored;
-                this.isVisible = options?.isVisible || defaults.isVisible;
-                if (this.x && this.y && !this.$element) {
-                    const cellId = this.constructor.getCellId(this.x, this.y);
-                    this.$element = document.getElementById(cellId);
-                }
-
-                if (this.$element) {
-                    this.refreshElement();
-                }
-
-                const handler = {
-                    set: (target, prop, value) => {
-                        const oldVal = target[prop];
-                        if (oldVal !== value) {
-                            target[prop] = value;
-                            this.refreshElement();
-                        }
-                        return true;
-                    }
-                };
-
-                return new Proxy(this, handler);
-            }
-
-            refreshElement() {
-                if (!this.$element) {
-                    console.warn("MapCell has no element to refresh");
-                    return;
-                }
-
-                let tile = '';
-                let tileClass = '';
-                if (!this.isExplored) {
-                    tile = '?';
-                    tileClass = 'unexplored';
-                } else {
-                    // Use a visibility function if one is available
-                    // Otherwise, assume that the tile is visible
-                    const isVisible = typeof this.isVisible !== 'function' || this.isVisible();
-
-                    if (isVisible) {
-                        tile = this.mapCharacter || '?';
-                        tileClass = this.type || 'unknown';
-                        tileClass = tileClass === 'mimic' ? 'treasureChest' : tileClass;
-                    } else {
-                        const emptyCell = new MapCell();
-                        tile = emptyCell.mapCharacter;
-                        tileClass = emptyCell.type;
-                    }
-                }
-                /*
-                const displayName =
-                    (x === player.x && y === player.y)
-                        ? 'You ヽ(°٢° )ノ'
-                        : (MAP[y][x]?.isExplored
-                            ? MAP[y][x].displayName
-                            : "Unexplored"
-                        );
-                */
-                const displayName = this.isExplored
-                    ? this.displayName
-                    : "Unexplored";
-
-                this.$element.className = tileClass;
-
-                const hasCoordinates =
-                    typeof this.x === "number" &&
-                    typeof this.y === "number";
-
-                if (hasCoordinates) {
-                    this.$element.setAttribute(
-                        'data-tooltipHtml',
-                        `<div class="mapCellDetails">
-                            <div class="enlargedTile ${tileClass}">${tile}</div>
-                            <div class="details">
-                                <div class="name">${displayName}</div>
-                                <div class="coordinates">(${this.x}, ${this.y})</div>
-                            </div>
-                        </div>`
-                    );
-
-                    this.$element.setAttribute('data-tooltipPosition', 'right');
-                } else {
-                    this.$element.removeAttribute('data-tooltipHtml');
-                    this.$element.removeAttribute('data-tooltipPosition');
-                }
-
-                this.$element.innerText = tile;
-                Tooltip.refresh(this.$element);
-            }
-
-            static defaultsByType(type) {
-                /**
-                 * A MapCell can have the following properties:
-                 *
-                 * displayName
-                 *   The name that is displayed for the tile when hovering it on
-                 *   the minimap
-                 *
-                 * mapCharacter
-                 *   The character that represents the tile on the minimap
-                 *
-                 * isSolid
-                 *   If true, acts like a wall and does not allow the player to
-                 *   step onto it
-                 *
-                 * onEnter
-                 *   A function that runs when the player steps onto the tile.
-                 *   Always called with its own x, y coordinates. Won't work
-                 *   when isSolid = true
-                 *
-                 * onTouch
-                 *   A function that runs when the player touches the tile.
-                 *   Won't work when isSolid = false
-                 *
-                 * onExplode
-                 *   A function that runs when the player has blasted the tile
-                 *   with a brick of C4. Always called with its own x, y
-                 *   coordinates
-                 *
-                 * isExplored
-                 *   When false, the cell appears as "Unexplored" on the minimap
-                 *
-                 * isVisible
-                 *   A function that determines if the tile is visible. If it
-                 *   returns false, the tile appears as a generic floor instead
-                 */
-                const defaults = {
-                    displayName: "Unknown",
-                    mapCharacter: "?",
-                    isSolid: false,
-                    onEnter: null,
-                    onTouch: null,
-                    onExplode: null,
-                    isExplored: true,
-                    isVisible: null,
-                };
-
-                const types = {
-                    floor: {
-                        displayName: "Floor",
-                        mapCharacter: ".",
-                    },
-                    healingTile: {
-                        displayName: "Healing Tile",
-                        mapCharacter: "H",
-                        onEnter: function (x, y) {
-                            player.steppingOnHealingTile = true;
-
-                            // Heal 30% of effective max HP
-                            const healAmount = Math.ceil(getEffectiveStat('maxHp') * 0.3);
-                            player.heal(healAmount);
-                            updateBattleLog(
-                                `An oddly colored, perfectly square floor ` +
-                                `tile <span class="friendly">heals you for ` +
-                                `<span class="healingTile">${healAmount} HP ` +
-                                `</span></span>`
-                            );
-
-                            MAP[y][x] = new MapCell("floor", { x, y });
-                        },
-                    },
-                    wall: {
-                        displayName: "Wall",
-                        mapCharacter: "#",
-                        isSolid: true,
-                        onExplode: function (x, y) {
-                            MAP[y][x] = new MapCell(
-                                Math.random() < 0.5 ? 'rubble1' : 'rubble2',
-                                { x, y, $element: this.$element }
-                            );
-                        },
-                    },
-                    iceWall: {
-                        displayName: "Wall",
-                        mapCharacter: '#',
-                        isSolid: true,
-                        onExplode: function (x, y) {
-                            MAP[y][x] = new MapCell(
-                                Math.random() < 0.5 ? 'rubble1' : 'rubble2',
-                                { x, y, $element: this.$element }
-                            );
-                        },
-                    },
-                    crackedFloorSlight: {
-                        displayName: "Slightly-Cracked Floor",
-                        mapCharacter: '✕',
-                        onEnter: function (x, y) {
-                            const key = `${x},${y}`;
-                            // Determine step threshold based on carry weight
-                            const percent = getCarryWeight() / getCarryWeightLimit();
-                            let threshold = 3;
-                            if (percent >= 0.8) threshold = 1;
-                            else if (percent >= 0.5) threshold = 2;
-
-                            crackedFloorSteps[key] = (crackedFloorSteps[key] || 0) + 1;
-
-                            if (crackedFloorSteps[key] < threshold) {
-                                // Not yet breaking, but upgrade to severe if not already
-                                if (MAP[y][x].type !== 'crackedFloorSevere') {
-                                    MAP[y][x] = new MapCell(
-                                        'crackedFloorSevere',
-                                        { x, y, $element: this.$element }
-                                    );
-                                    updateBattleLog(
-                                        '<span class="action">The floor cracks under ' +
-                                        'your feet!</span>'
-                                    );
-                                    playSFX('floorCrackSlight');
-                                }
-                            } else {
-                                player.fallThroughFloorAndDie();
-                            }
-                        },
-                    },
-                    crackedFloorSevere: {
-                        displayName: "Severely-Cracked Floor",
-                        mapCharacter: '✖',
-                        onEnter: function (x, y) {
-                            const key = `${x},${y}`;
-                            // Determine step threshold based on carry weight
-                            const percent = getCarryWeight() / getCarryWeightLimit();
-                            let threshold = 3;
-                            if (percent >= 0.8) threshold = 1;
-                            else if (percent >= 0.5) threshold = 2;
-
-                            crackedFloorSteps[key] = (crackedFloorSteps[key] || 0) + 1;
-
-                            if (crackedFloorSteps[key] < threshold) {
-                                // Still not breaking, but warn
-                                updateBattleLog(
-                                    '<span class="action">The floor cracks even more under your feet!</span> One more step and you\'re done for!'
-                                );
-                                playSFX('floorCrackSlight');
-                            } else {
-                                player.fallThroughFloorAndDie();
-                            }
-                        },
-                    },
-                    rubble1: {
-                        displayName: "Floor",
-                        mapCharacter: ".",
-                        onExplode: function (x, y) {
-                            MAP[y][x] = new MapCell(
-                                'rubble2',
-                                { x, y, $element: this.$element }
-                            );
-                        },
-                    },
-                    rubble2: {
-                        displayName: "Floor",
-                        mapCharacter: ".",
-                        onExplode: function (x, y) {
-                            MAP[y][x] = new MapCell(
-                                'rubble1',
-                                { x, y, $element: this.$element },
-                            );
-                        },
-                    },
-                    gloryWall: {
-                        displayName: "Wall",
-                        mapCharacter: "#",
-                        isSolid: true,
-                        onTouch: function() {
-                            player.say("Uh, no thanks. I'm not THAT brave");
-                        },
-                        onExplode: function (x, y) {
-                            MAP[y][x] = new MapCell(
-                                Math.random() < 0.5 ? 'rubble1' : 'rubble2',
-                                { x, y, $element: this.$element }
-                            );
-                        },
-                    },
-                    noboWall: {
-                        displayName: "Wall",
-                        mapCharacter: "#",
-                        isSolid: true,
-                        onTouch: function () {
-                            player.say(
-                                "Who's that? ... Just some nobody, I guess"
-                            );
-                        },
-                        onExplode: function (x, y) {
-                            MAP[y][x] = new MapCell(
-                                Math.random() < 0.5 ? 'rubble1' : 'rubble2',
-                                { x, y, $element: this.$element }
-                            );
-                        },
-                    },
-                    crater: {
-                        displayName: "Floor",
-                        mapCharacter: ".",
-                    },
-                    bloodyCrater: {
-                        displayName: "Floor",
-                        mapCharacter: ".",
-                    },
-                    exit: {
-                        displayName: "Exit",
-                        mapCharacter: "E",
-                        onEnter: function() {
-                            descend();
-                        }
-                    },
-                    merchant: {
-                        displayName: "Merchant",
-                        mapCharacter: "M",
-                        onEnter: function() {
-                            menu.open('merchant');
-                        },
-                        isVisible: function() {
-                            return (
-                                merchant.isAlive &&
-                                merchant.isActiveOnFloor
-                            );
-                        },
-                        onExplode: function (x, y) {
-                            merchant.isAlive = false;
-                            merchant.isActiveOnFloor = false;
-                            MAP[y][x] = new MapCell(
-                                'bloodyCrater',
-                                { x, y, $element: this.$element }
-                            );
-                            playSFX('scream');
-                            merchant.say('AIEEEEEEEEEEEEEE!', true);
-                            updateBattleLog(
-                                'HOLY SHIT! The <span class="friendly">' +
-                                'merchant</span> has been ' +
-                                '<span class="action">vaporized</span> into ' +
-                                'a bloody red mist!'
-                            );
-                        },
-                    },
-                    gambler: {
-                        displayName: "Gambler",
-                        mapCharacter: "G",
-                        onEnter: function() {
-                            menu.open('gambler');
-                        },
-                        isVisible: function () {
-                            return (
-                                gambler.isAlive &&
-                                gambler.isActiveOnFloor &&
-                                player.bitcoins >= gambler.playPrice
-                            );
-                        },
-                        onExplode: function (x, y) {
-                            gambler.isAlive = false;
-                            gambler.isActiveOnFloor = false;
-                            MAP[y][x] = new MapCell(
-                                'bloodyCrater',
-                                { x, y, $element: this.$element }
-                            );
-
-                            // Award between 50 and 100 BTC for the slaughter. I guess that's one way to win
-                            const rewardBtc = (5 + Math.round(Math.random() * 5)) * 10;
-                            player.giveBitcoins(rewardBtc);
-                            playSFX('scream');
-                            gambler.say('AUGH!!', true);
-                            updateBattleLog(
-                                `The <span class="gambler">gambler</span> ` +
-                                `has been reduced to a confetti of shrapnel ` +
-                                `and bone! You find <span class="BTC">` +
-                                `${rewardBtc} BTC</span> among the remains. ` +
-                                `Awesome!`
-                            );
-                        },
-                    },
-                    tardspireBanner: {
-                        displayName: "Floor",
-                        mapCharacter: ".",
-                        onEnter: function (x, y) {
-                            MAP[y][x] = new MapCell(
-                                "floor",
-                                { x, y, $element: this.$element }
-                            );
-                        },
-                        onExplode: function (x, y) {
-                            MAP[y][x] = new MapCell(
-                                "floor",
-                                { x, y, $element: this.$element }
-                            );
-                        },
-                    },
-                    treasureChest: {
-                        displayName: "Treasure Chest",
-                        mapCharacter: "T",
-                        onEnter: function() {
-                            menu.open("chest");
-                        },
-                        onExplode: function (x, y) {
-                            MAP[y][x] = new MapCell(
-                                'crater',
-                                { x, y, $element: this.$element }
-                            );
-                            updateBattleLog(
-                                '<span class="action">Gee willikers, you ' +
-                                'just destroyed a perfectly good treasure ' +
-                                'chest! Oh well...</span><br>'
-                            );
-                        },
-                    },
-                    mimic: {
-                        displayName: "Treasure Chest",
-                        mapCharacter: "T",
-                        onEnter: function () {
-                            menu.open("chest");
-                        },
-                        onExplode: function (x, y) {
-                            MAP[y][x] = new MapCell(
-                                'bloodyCrater',
-                                { x, y, $element: this.$element }
-                            );
-
-                            // Calculate scaled BTC reward
-                            const baseMimic = enemies.find(e => e.id === "mimic");
-                            const scaledMimic = scaleMimicStats(baseMimic);
-                            const mimicBTC = scaledMimic.bitcoins;
-
-                            player.giveBitcoins(mimicBTC); // Reward the player
-                            updateBattleLog(
-                                `<span class="action">WHAT THE FUCK? That ` +
-                                `was a mimic?!</span> You obtained ` +
-                                `<span class="BTC">${mimicBTC} BTC</span> ` +
-                                `from the intestines spilled from its gaping ` +
-                                `maw.`
-                            );
-                            playSFX('scream');
-                        },
-                    },
-                };
-
-                return { ...defaults, ...(types[type] || {}) };
-            }
-        }
 
 
         const
@@ -7091,6 +6614,7 @@ A Javascript game by <a href="https://milklounge.wang/tardquest/" target="_blank
             ring1: null,
             ring2: null,
             movementDisabled: false,
+            getDisplayCharacter: () => ["↑", "→", "↓", "←"][player.dir] || "?",
             say: function(str) {
                 const message = str.trim();
                 if (message) {
@@ -7391,6 +6915,8 @@ A Javascript game by <a href="https://milklounge.wang/tardquest/" target="_blank
                             .querySelector(`progress-bar.health-bar`);
                         $healthBar.setAttribute('value', partyMember.hp);
                     }
+
+                    player.party.refreshPartyCount();
                 },
                 purgeDeadMembers: () => {
                     const aliveMembers = [];
@@ -7418,6 +6944,7 @@ A Javascript game by <a href="https://milklounge.wang/tardquest/" target="_blank
                     }
 
                     player.party.members = aliveMembers;
+                    player.party.refreshPartyCount();
                 },
                 talk: (partyMemberId) => {
                     const index = partyMemberId === undefined
@@ -7505,6 +7032,13 @@ A Javascript game by <a href="https://milklounge.wang/tardquest/" target="_blank
                     updateBattleLog(`You boot ${partyMember.name} to the curb. SEE YA!`);
                     player.party.members = player.party.members.filter((e) => e.id !== partyMemberId);
                     document.querySelector(`#partyMembers [data-partyMemberId="${partyMemberId}"]`).remove();
+                    player.party.refreshPartyCount();
+                },
+                refreshPartyCount: () => {
+                    document.getElementById("totalPartyMembers").innerText =
+                        player.party.members.length.toLocaleString(undefined);
+                    document.getElementById("maxPartyMembers").innerText =
+                        player.party.maxMembers.toLocaleString(undefined);
                 },
                 get: () => player.party.members.filter((e) => e.hp > 0),
                 prepareForBattle: () => player.party.members
@@ -7532,22 +7066,13 @@ A Javascript game by <a href="https://milklounge.wang/tardquest/" target="_blank
                 return (
                     merchant.isAlive &&
                     merchant.isActiveOnFloor &&
-                    MAP[y][x]?.type === 'merchant'
+                    MAP.getCell(x, y)?.type === 'merchant'
                 );
             },
             location: function() {
-                if (!merchant.isAlive || !merchant.isActiveOnFloor) {
-                    return null;
-                }
-
-                for (let y = 0; y < MAP.length; y++) {
-                    for (let x = 0; x < MAP[y].length; x++) {
-                        if (MAP[y][x]?.type === "merchant") {
-                            return { x, y };
-                        }
-                    }
-                }
-                return null;
+                return merchant.isAlive && merchant.isActiveOnFloor
+                    ? MAP.locate("merchant")
+                    : null;
             },
             buy: function(type, key) {
                 const merchandise = merchant.getMerchandiseCollection(type)?.[key];
@@ -7651,11 +7176,11 @@ A Javascript game by <a href="https://milklounge.wang/tardquest/" target="_blank
                     const y = Math.floor(Math.random() * HEIGHT);
 
                     const isEmptySpace =
-                        MAP[y][x]?.type === 'floor' &&
+                        MAP.getCell(x, y)?.type === 'floor' &&
                         (y !== player.y && x !== player.x);
 
                     if (isEmptySpace) {
-                        MAP[y][x] = new MapCell('merchant', { x, y });
+                        MAP.setCell(x, y, "merchant");
                         return;
                     }
                 } while (attempts++ < 1000);
@@ -7732,7 +7257,7 @@ A Javascript game by <a href="https://milklounge.wang/tardquest/" target="_blank
                     gambler.isAlive &&
                     gambler.isActiveOnFloor &&
                     player.bitcoins >= gambler.playPrice &&
-                    MAP[y][x]?.type === 'gambler'
+                    MAP.getCell(x, y)?.type === 'gambler'
                 );
             },
             location: function() {
@@ -7740,14 +7265,7 @@ A Javascript game by <a href="https://milklounge.wang/tardquest/" target="_blank
                     return null;
                 }
 
-                for (let y = 0; y < MAP.length; y++) {
-                    for (let x = 0; x < MAP[y].length; x++) {
-                        if (MAP[y][x]?.type === "gambler") {
-                            return { x, y };
-                        }
-                    }
-                }
-                return null;
+                return MAP.locate("gambler");
             },
             set: function() {
                 let attempts = 0;
@@ -7758,15 +7276,15 @@ A Javascript game by <a href="https://milklounge.wang/tardquest/" target="_blank
 
                     const isMerchantSpace =
                         merchant.isActiveOnFloor &&
-                        MAP[y][x]?.type === 'merchant';
+                        MAP.getCell(x, y)?.type === 'merchant';
 
                     const isEmptySpace =
-                        MAP[y][x]?.type === 'floor' &&
+                        MAP.getCell(x, y)?.type === 'floor' &&
                         (y !== player.y && x !== player.x) &&
                         !isMerchantSpace;
 
                     if (isEmptySpace) {
-                        MAP[y][x] = new MapCell('gambler', { x, y });
+                        MAP.setCell(x, y, "gambler");
                         return;
                     }
                 } while (attempts++ < 1000);
@@ -8004,18 +7522,14 @@ A Javascript game by <a href="https://milklounge.wang/tardquest/" target="_blank
                 name: "DOWSING ROD",
                 description: "A Y-shaped stick. Reveals the exit of the current floor. +1.7 LOAD",
                 use: () => {
-                    for (let y=0; y<MAP.length; y++) {
-                        for (let x=0; x<MAP[y].length; x++) {
-                            if (MAP[y][x]?.type === 'exit') {
-                                revealMapSpot(x, y, 1);
-
-                                // Since there's only one exit per floor, we can render and exit early
-                                updateBattleLog("The exit has been revealed!");
-                                render();
-                                return;
-                            }
-                        }
+                    const location = MAP.locate("exit");
+                    if (!location) {
+                        console.error("No exit exists on this map!");
+                        return;
                     }
+
+                    MAP.revealSpot(location.x, location.y, 1);
+                    updateBattleLog("The exit has been revealed!");
                 },
                 merchantStockChance: 0.8,
                 weight: 1.7,
@@ -8031,7 +7545,7 @@ A Javascript game by <a href="https://milklounge.wang/tardquest/" target="_blank
                         return;
                     }
                     playSFX('torch');
-                    MAP.forEach((mapY) => columns.forEach((mapY) => cell.isExplored = true));
+                    MAP.reveal();
                     updateBattleLog("Lo, the way has been made clear!");
                     animTorchStart();
                     render();
@@ -8055,11 +7569,8 @@ A Javascript game by <a href="https://milklounge.wang/tardquest/" target="_blank
                                 playSFX('scream');
                                 const nx = player.x + DX[player.dir];
                                 const ny = player.y + DY[player.dir];
-                                if (['floor', 'rubble1', 'rubble2'].includes(MAP[ny]?.[nx]?.type)) {
-                                    MAP[ny][nx] = new MapCell(
-                                        'bloodyCrater',
-                                        { x: nx, y: ny }
-                                    );
+                                if (['floor', 'rubble1', 'rubble2'].includes(MAP.getCell(nx, ny)?.type)) {
+                                    MAP.setCell(nx, ny, "bloodyCrater");
                                 }
                             }
                             endOfPlayerTurn();
@@ -8092,16 +7603,15 @@ A Javascript game by <a href="https://milklounge.wang/tardquest/" target="_blank
 
                             for (let y=yMin; y<=yMax; y++) {
                                 for (let x=xMin; x<=xMax; x++) {
-                                    if (MAP[y]?.[x]) {
-                                        const isVisible =
-                                            typeof MAP[y][x].isVisible !== 'function' ||
-                                            MAP[y][x].isVisible();
+                                    const cell = MAP.getCell(x, y);
+                                    const isVisible =
+                                        typeof cell.isVisible !== 'function' ||
+                                        cell.isVisible();
 
-                                        if (isVisible) {
-                                            MAP[y][x]?.onExplode?.(x, y);
-                                        }
-                                        MAP[y][x].isExplored = true;
+                                    if (isVisible) {
+                                        cell?.onExplode?.(x, y);
                                     }
+                                    cell.isExplored = true;
                                 }
                             }
 
@@ -8446,16 +7956,6 @@ A Javascript game by <a href="https://milklounge.wang/tardquest/" target="_blank
             return player[stat] + ringsEquipped.reduce((sum, ring) => sum + (ring.effects?.[stat] || 0), 0);
         }
 
-        function revealMapSpot(x, y, radius) {
-            for (let py=y-radius; py<=y+radius; py++) {
-                for (let px=x-radius; px<=x+radius; px++) {
-                    if (typeof MAP[py]?.[px] !== "undefined") {
-                        MAP[py][px].isExplored = true;
-                    }
-                }
-            }
-        }
-
         const sfx = {
             footstep: new Audio('audio/footsteps.wav'),
             turn: new Audio('audio/turn.wav'),
@@ -8555,14 +8055,273 @@ A Javascript game by <a href="https://milklounge.wang/tardquest/" target="_blank
         let speakingOutsideCombat = false;
         let animationActive = false;
         let currentBreathing = null;
-        let battleLog = [];
         let floor = 1;
-        let MAP = [];
-        const crackedFloorSteps = {};
-        let exit = {
-            x: WIDTH - 2,
-            y: HEIGHT - 2
-        };
+        const MAP = new Map();
+        MAP.setMinimap(document.getElementById("minimap"));
+
+        MAP.setCellTypes({
+            floor: {
+                displayName: "Floor",
+                mapCharacter: ".",
+            },
+            healingTile: {
+                displayName: "Healing Tile",
+                mapCharacter: "H",
+                onEnter: function (x, y) {
+                    player.steppingOnHealingTile = true;
+
+                    // Heal 30% of effective max HP
+                    const healAmount = Math.ceil(getEffectiveStat('maxHp') * 0.3);
+                    player.heal(healAmount);
+                    updateBattleLog(
+                        `An oddly colored, perfectly square floor ` +
+                        `tile <span class="friendly">heals you for ` +
+                        `<span class="healingTile">${healAmount} HP ` +
+                        `</span></span>`
+                    );
+
+                    MAP.setCell(x, y);
+                },
+            },
+            wall: {
+                displayName: "Wall",
+                mapCharacter: "#",
+                isSolid: true,
+                onExplode: function (x, y) {
+                    const type = Math.random() < 0.5 ? 'rubble1' : 'rubble2';
+                    MAP.setCell(x, y, type);
+                },
+            },
+            iceWall: {
+                displayName: "Wall",
+                mapCharacter: '#',
+                isSolid: true,
+                onExplode: function (x, y) {
+                    const type = Math.random() < 0.5 ? 'rubble1' : 'rubble2';
+                    MAP.setCell(x, y, type);
+                },
+            },
+            crackedFloorSlight: {
+                displayName: "Slightly-Cracked Floor",
+                mapCharacter: '✕',
+                onEnter: function (x, y) {
+                    const key = `${x},${y}`;
+                    // Determine step threshold based on carry weight
+                    const percent = getCarryWeight() / getCarryWeightLimit();
+                    let threshold = 3;
+                    if (percent >= 0.8) threshold = 1;
+                    else if (percent >= 0.5) threshold = 2;
+
+                    crackedFloorSteps[key] = (crackedFloorSteps[key] || 0) + 1;
+
+                    if (crackedFloorSteps[key] < threshold) {
+                        // Not yet breaking, but upgrade to severe if not already
+                        /*
+                        if (MAP[y][x].type !== 'crackedFloorSevere') {
+                            MAP[y][x] = new MapCell(
+                                'crackedFloorSevere',
+                                { x, y, $element: this.$element }
+                            );
+                            updateBattleLog(
+                                '<span class="action">The floor cracks under ' +
+                                'your feet!</span>'
+                            );
+                            playSFX('floorCrackSlight');
+                        }
+                        */
+                    } else {
+                        player.fallThroughFloorAndDie();
+                    }
+                },
+            },
+            crackedFloorSevere: {
+                displayName: "Severely-Cracked Floor",
+                mapCharacter: '✖',
+                onEnter: function (x, y) {
+                    const key = `${x},${y}`;
+                    // Determine step threshold based on carry weight
+                    const percent = getCarryWeight() / getCarryWeightLimit();
+                    let threshold = 3;
+                    if (percent >= 0.8) threshold = 1;
+                    else if (percent >= 0.5) threshold = 2;
+
+                    crackedFloorSteps[key] = (crackedFloorSteps[key] || 0) + 1;
+
+                    if (crackedFloorSteps[key] < threshold) {
+                        // Still not breaking, but warn
+                        updateBattleLog(
+                            '<span class="action">The floor cracks even more under your feet!</span> One more step and you\'re done for!'
+                        );
+                        playSFX('floorCrackSlight');
+                    } else {
+                        player.fallThroughFloorAndDie();
+                    }
+                },
+            },
+            rubble1: {
+                displayName: "Floor",
+                mapCharacter: ".",
+                onExplode: function (x, y) {
+                    MAP.setCell(x, y, "rubble2");
+                },
+            },
+            rubble2: {
+                displayName: "Floor",
+                mapCharacter: ".",
+                onExplode: function (x, y) {
+                    MAP.setCell(x, y, "rubble1");
+                },
+            },
+            gloryWall: {
+                displayName: "Wall",
+                mapCharacter: "#",
+                isSolid: true,
+                onTouch: function() {
+                    player.say("Uh, no thanks. I'm not THAT brave");
+                },
+                onExplode: function (x, y) {
+                    const type = Math.random() < 0.5 ? 'rubble1' : 'rubble2';
+                    MAP.setCell(x, y, type);
+                },
+            },
+            noboWall: {
+                displayName: "Wall",
+                mapCharacter: "#",
+                isSolid: true,
+                onTouch: function () {
+                    player.say(
+                        "Who's that? ... Just some nobody, I guess"
+                    );
+                },
+                onExplode: function (x, y) {
+                    const type = Math.random() < 0.5 ? 'rubble1' : 'rubble2';
+                    MAP.setCell(x, y, type);
+                },
+            },
+            crater: {
+                displayName: "Floor",
+                mapCharacter: ".",
+            },
+            bloodyCrater: {
+                displayName: "Floor",
+                mapCharacter: ".",
+            },
+            exit: {
+                displayName: "Exit",
+                mapCharacter: "E",
+                onEnter: function() {
+                    descend();
+                }
+            },
+            merchant: {
+                displayName: "Merchant",
+                mapCharacter: "M",
+                onEnter: function() {
+                    menu.open('merchant');
+                },
+                isVisible: function() {
+                    return (
+                        merchant.isAlive &&
+                        merchant.isActiveOnFloor
+                    );
+                },
+                onExplode: function (x, y) {
+                    merchant.isAlive = false;
+                    merchant.isActiveOnFloor = false;
+                    MAP.setCell(x, y, "bloodyCrater");
+                    playSFX('scream');
+                    merchant.say('AIEEEEEEEEEEEEEE!', true);
+                    updateBattleLog(
+                        'HOLY SHIT! The <span class="friendly">' +
+                        'merchant</span> has been ' +
+                        '<span class="action">vaporized</span> into ' +
+                        'a bloody red mist!'
+                    );
+                },
+            },
+            gambler: {
+                displayName: "Gambler",
+                mapCharacter: "G",
+                onEnter: function() {
+                    menu.open('gambler');
+                },
+                isVisible: function () {
+                    return (
+                        gambler.isAlive &&
+                        gambler.isActiveOnFloor &&
+                        player.bitcoins >= gambler.playPrice
+                    );
+                },
+                onExplode: function (x, y) {
+                    gambler.isAlive = false;
+                    gambler.isActiveOnFloor = false;
+                    MAP.setCell(x, y, "bloodyCrater");
+
+                    // Award between 50 and 100 BTC for the slaughter. I guess that's one way to win
+                    const rewardBtc = (5 + Math.round(Math.random() * 5)) * 10;
+                    player.giveBitcoins(rewardBtc);
+                    playSFX('scream');
+                    gambler.say('AUGH!!', true);
+                    updateBattleLog(
+                        `The <span class="gambler">gambler</span> ` +
+                        `has been reduced to a confetti of shrapnel ` +
+                        `and bone! You find <span class="BTC">` +
+                        `${rewardBtc} BTC</span> among the remains. ` +
+                        `Awesome!`
+                    );
+                },
+            },
+            tardspireBanner: {
+                displayName: "Floor",
+                mapCharacter: ".",
+                onEnter: function (x, y) {
+                    MAP.setCell(x, y);
+                },
+                onExplode: function (x, y) {
+                    MAP.setCell(x, y);
+                },
+            },
+            treasureChest: {
+                displayName: "Treasure Chest",
+                mapCharacter: "T",
+                onEnter: function() {
+                    menu.open("chest");
+                },
+                onExplode: function (x, y) {
+                    MAP.setCell(x, y, "crater");
+                    updateBattleLog(
+                        '<span class="action">Gee willikers, you ' +
+                        'just destroyed a perfectly good treasure ' +
+                        'chest! Oh well...</span><br>'
+                    );
+                },
+            },
+            mimic: {
+                displayName: "Treasure Chest",
+                mapCharacter: "T",
+                onEnter: function () {
+                    menu.open("chest");
+                },
+                onExplode: function (x, y) {
+                    MAP.setCell(x, y, "bloodyCrater");
+
+                    // Calculate scaled BTC reward
+                    const baseMimic = enemies.find(e => e.id === "mimic");
+                    const scaledMimic = scaleMimicStats(baseMimic);
+                    const mimicBTC = scaledMimic.bitcoins;
+
+                    player.giveBitcoins(mimicBTC); // Reward the player
+                    updateBattleLog(
+                        `<span class="action">WHAT THE FUCK? That ` +
+                        `was a mimic?!</span> You obtained ` +
+                        `<span class="BTC">${mimicBTC} BTC</span> ` +
+                        `from the intestines spilled from its gaping ` +
+                        `maw.`
+                    );
+                    playSFX('scream');
+                },
+            },
+        });
 
         let musicEnabled = true;
         let sfxEnabled = true;
@@ -8571,48 +8330,12 @@ A Javascript game by <a href="https://milklounge.wang/tardquest/" target="_blank
         let eatRatAnimationEnabled = true;
 
         function generateMap() {
-            setExitPosition();
+            MAP.generate(WIDTH, HEIGHT, player.x, player.y);
 
-            // Fill in walls
-            for (let y = 0; y < HEIGHT; y++) {
-                MAP[y] = [];
-                for (let x = 0; x < WIDTH; x++) {
-                    MAP[y][x] = new MapCell(
-                        'wall',
-                        { x, y, isExplored: false }
-                    );
-                }
-            }
-
-            // Carve out a path
-            let position = { x: player.x, y: player.y };
-            let stack = null;
-            do {
-                stack = carvePath([position]);
-            } while (stack === null);
-
-            for (let i in stack) {
-                MAP[stack[i].y][stack[i].x] = new MapCell(
-                    'floor',
-                    { x: stack[i].x, y: stack[i].y, isExplored: false }
-                );
-            }
-
-            for (let i = 0; i < 10; i++) {
-                dissolveMap();
-            }
-
-            MAP[player.y][player.x] = new MapCell('floor', {
-                x: player.x,
-                y: player.y,
-            });
-
-            MAP[exit.y][exit.x] = new MapCell('exit', {
-                x: exit.x,
-                y: exit.y,
-                isExplored: false,
-            });
-
+            /**
+             * @TODO: Finish reorganizing map generation functionality so that
+             *        these can be re-enabled
+             *
             // 100% chance to spawn merchant on floor 1
             if (floor === 1) {
                 merchant.isActiveOnFloor = merchant.isAlive;
@@ -8653,6 +8376,7 @@ A Javascript game by <a href="https://milklounge.wang/tardquest/" target="_blank
 
                 $minimap.append(document.createElement('br'));
             }
+            */
 
             document.getElementById('minimapHeader').innerText =
                 `Dungeon Floor ${floor}`;
@@ -8808,144 +8532,16 @@ A Javascript game by <a href="https://milklounge.wang/tardquest/" target="_blank
             return availableItems[Math.floor(Math.random() * availableItems.length)];
         }
 
-        function setExitPosition() {
-            const margin = 2;
-            const possiblePositions = [['x', 'y'], ['x'], ['y']];
-            const positions = possiblePositions[
-                Math.floor(Math.random() * possiblePositions.length)
-            ];
-
-            for (let p in positions) {
-                if (positions[p] === 'x') {
-                    const exitOffsetX = Math.round(Math.random() * Math.round(WIDTH / 10));
-                    if (player.x < WIDTH / margin) {
-                        exit.x = WIDTH - margin - exitOffsetX;
-                    } else {
-                        exit.x = margin + exitOffsetX;
-                    }
-                } else {
-                    const exitOffsetY = Math.round(Math.random() * Math.round(HEIGHT / 10));
-                    if (player.y < HEIGHT / margin) {
-                        exit.y = HEIGHT - margin - exitOffsetY;
-                    } else {
-                        exit.y = margin + exitOffsetY;
-                    }
-                }
-            }
-        }
-
-        function carvePath(stack) {
-            const direction = Math.random() < 0.5 ? 'horizontal' : 'vertical';
-            const step = Math.random() < 0.5 ? -1 : 1;
-            let lastPosition = stack[stack.length - 1];
-
-            for (let i=0; i<2; i++) {
-                const nextPosition = {
-                    x: lastPosition.x + (direction === 'horizontal' ? step : 0),
-                    y: lastPosition.y + (direction === 'vertical' ? step : 0),
-                };
-
-                const atMapEdge =
-                    nextPosition.x === 0 ||
-                    nextPosition.y === 0 ||
-                    nextPosition.x === WIDTH - 1 ||
-                    nextPosition.y === HEIGHT - 1;
-
-                if (atMapEdge) {
-                    return null;
-                }
-
-                const alreadyVisited = stack.find((cell) =>
-                    cell.x === nextPosition.x && cell.y === nextPosition.y
-                );
-                if (alreadyVisited) {
-                    return null;
-                }
-
-                stack.push(nextPosition);
-
-                const reachedEnd =
-                    nextPosition.x === exit.x &&
-                    nextPosition.y === exit.y;
-
-                if (reachedEnd) {
-                    return stack;
-                }
-
-                lastPosition = nextPosition;
-            }
-
-            let result;
-            for (let i=0; i<100; i++) {
-                result = carvePath(stack);
-                if (result) {
-                    break;
-                }
-            }
-
-            return result;
-        }
-
-        function getMapDissolvePoints() {
-            const dissolvePoints = [];
-            for (let y = 2; y < HEIGHT - 2; y++) {
-                for (let x = 2; x < WIDTH - 2; x++) {
-                    const isDissolvePoint = MAP[y][x]?.type === 'wall' && (
-                        (MAP[y - 1][x]?.type === 'wall' ? 1 : 0) +
-                        (MAP[y + 1][x]?.type === 'wall' ? 1 : 0) +
-                        (MAP[y][x - 1]?.type === 'wall' ? 1 : 0) +
-                        (MAP[y][x + 1]?.type === 'wall' ? 1 : 0)
-                    ) === 3;
-
-                    if (isDissolvePoint) {
-                        dissolvePoints.push({x, y});
-                    }
-                }
-            }
-
-            return dissolvePoints;
-        }
-
-        function dissolveMap() {
-            let dissolvePoints = getMapDissolvePoints();
-            const totalPointsToDissolve = Math.floor(dissolvePoints.length / 2);
-            if (totalPointsToDissolve < 1) {
-                return;
-            }
-
-            for (let i = 0; i < totalPointsToDissolve; i++) {
-                const index = Math.floor(Math.random() * dissolvePoints.length);
-                const dissolvePoint = dissolvePoints[index];
-                MAP[dissolvePoint.y][dissolvePoint.x] = new MapCell(
-                    'floor',
-                    { x: dissolvePoint.x, y: dissolvePoint.y }
-                );
-                dissolvePoints = dissolvePoints.splice(index, 1);
-            }
-        }
-
         function updateSeenTiles() {
              // Default reveal radius 1, 2 if Ring of Sightliness equipped
             const radius = player.hasEquippedRing('ringOfSightliness') ? 2 : 1;
-            revealMapSpot(player.x, player.y, radius);
+            MAP.revealSpot(player.x, player.y, radius);
         }
 
         function updateBattleLog(entry) {
-            battleLog.push(entry);
-            if (battleLog.length > 50) {
-                battleLog.shift();
-            }
-
-            const logContainer = document.getElementById("battleLog");
-            logContainer.innerHTML = [...battleLog]
-                .slice()
-                .reverse()
-                .map((msg, i) => {
-                    const lightness = 100 - (i * 4); // Fade effect
-                    const color = `hsl(0, 0%, ${Math.max(lightness, 60)}%)`;
-                    return `<div style="color: ${color};">${msg}</div>`;
-                })
-                .join("");
+            const line = document.createElement('div');
+            line.innerHTML = entry;
+            document.getElementById("battleLog").prepend(line);
         }
 
         function playSFX(name) {
@@ -8959,8 +8555,21 @@ A Javascript game by <a href="https://milklounge.wang/tardquest/" target="_blank
         }
 
         function render() {
+            MAP.setEntities({
+                player: {
+                    forceRefresh: true,
+                    x: player.x,
+                    y: player.y,
+                    displayName: `You <span class="player lets-go">ヽ(°٢° )ノ</span>`,
+                    isExplored: true,
+                    isVisible: true,
+                    mapCharacter: player.getDisplayCharacter(),
+                    type: "player",
+                },
+            });
             updateSeenTiles();
             updateBreathingSFX();
+            MAP.refreshMinimap();
 
             // @TODO: Keep this out of render()
             // Stat updates should update the appropriate sections on their own
@@ -9013,14 +8622,6 @@ A Javascript game by <a href="https://milklounge.wang/tardquest/" target="_blank
                 return false;
             }
             return true;
-        }
-
-        function getTile(x, y) {
-            return !coordsInBounds(x, y) ? new MapCell('wall') : MAP[y][x];
-        }
-
-        function coordsInBounds(x, y) {
-            return x >= 0 && x < WIDTH && y >= 0 && y < HEIGHT;
         }
 
         function animEatRat(callback) {
@@ -9202,7 +8803,7 @@ A Javascript game by <a href="https://milklounge.wang/tardquest/" target="_blank
                 randomEncounterChance *= 0.7; // If Ring of Stinky is equipped, reduce encounter chance by 30%
             }
 
-            const tile = getTile(nx, ny);
+            const tile = MAP.getCell(nx, ny);
             if (!tile.isSolid) {
                 player.x = nx;
                 player.y = ny;
@@ -9656,10 +9257,10 @@ A Javascript game by <a href="https://milklounge.wang/tardquest/" target="_blank
                 for (let i = 0; i < 4; i++) {
                     const nx = player.x + DX[i];
                     const ny = player.y + DY[i];
-                    if (coordsInBounds(nx, ny) && MAP[ny][nx]?.type === 'floor') {
+                    if (MAP.getCell(nx, ny)?.type === 'floor') {
                         merchant.isAlive = true;
                         merchant.isActiveOnFloor = true;
-                        MAP[ny][nx] = new MapCell('merchant', { x: nx, y: ny });
+                        MAP.setCell(nx, ny, 'merchant');
                         merchant.set();
                         updateBattleLog('<span class="merchant">CHEAT: Merchant spawned</span>');
                         found = true;
@@ -9676,12 +9277,12 @@ A Javascript game by <a href="https://milklounge.wang/tardquest/" target="_blank
                 for (let i = 0; i < 4; i++) {
                     const nx = player.x + DX[i];
                     const ny = player.y + DY[i];
-                    if (coordsInBounds(nx, ny) && MAP[ny][nx]?.type === 'floor') {
+                    if (MAP.getCell(nx, ny)?.type === 'floor') {
                         gambler.isAlive = true;
                         gambler.isActiveOnFloor = true;
                         player.bitcoins = Math.max(player.bitcoins, gambler.playPrice);
                         player.refreshBitcoins();
-                        MAP[ny][nx] = new MapCell('gambler', { x: nx, y: ny });
+                        MAP.setCell(nx, ny, 'gambler');
                         updateBattleLog('<span class="gambler">CHEAT: Gambler spawned</span>');
                         found = true;
                         break;
@@ -9804,11 +9405,11 @@ A Javascript game by <a href="https://milklounge.wang/tardquest/" target="_blank
                 for (let i = 0; i < 4; i++) {
                     const nx = player.x + DX[i];
                     const ny = player.y + DY[i];
-                    if (coordsInBounds(nx, ny) && MAP[ny][nx]?.type === 'floor') {
+                    if (MAP.getCell(nx, ny)?.type === 'floor') {
                         merchant.isAlive = true;
                         merchant.isActiveOnFloor = true;
                         merchant.setWares(true);
-                        MAP[ny][nx] = new MapCell('merchant', { x: nx, y: ny });
+                        MAP.setCell(nx, ny, 'merchant');
                         merchantSpawned = true;
                         break;
                     }
@@ -9826,17 +9427,13 @@ A Javascript game by <a href="https://milklounge.wang/tardquest/" target="_blank
                         const notPlayer = gx !== player.x || gy !== player.y;
                         const notMerchant = gx !== merchantPosition.x || gy !== merchantPosition.y;
                         if (
-                            coordsInBounds(gx, gy) &&
-                            MAP[gy][gx]?.type === 'floor' &&
+                            MAP.getCell(gx, gy)?.type === 'floor' &&
                             notPlayer &&
                             notMerchant
                         ) {
                             gambler.isAlive = true;
                             gambler.isActiveOnFloor = true;
-                            MAP[gy][gx] = new MapCell(
-                                'gambler',
-                                { x: gx, y: gy }
-                            );
+                            MAP.setCell(gx, gy, 'gambler');
                             gamblerSpawned = true;
                             break;
                         }
@@ -10103,15 +9700,12 @@ A Javascript game by <a href="https://milklounge.wang/tardquest/" target="_blank
 
 
         function openChest() {
-            if (MAP[player.y][player.x]?.type === 'mimic') {
+            if (MAP.getCell(player.x, player.y)?.type === 'mimic') {
                 // Mimic detected, start a battle
                 playSFX('scream');
 
                 // Remove the mimic from the map
-                MAP[player.y][player.x] = new MapCell(
-                    "floor",
-                    { x: player.y, y: player.y }
-                );
+                MAP.setCell(player.x, player.y);
 
                 // Spawn mimic and apply scaling
                 const baseMimic = enemies.find(e => e.id === "mimic");
@@ -10120,7 +9714,7 @@ A Javascript game by <a href="https://milklounge.wang/tardquest/" target="_blank
                 updateBattleLog("Holy shit! It was actually a <span class='enemy'>MIMIC</span>!!!");
                 player.enterCombat();
                 playRandomBattleMusic();
-            } else if (MAP[player.y][player.x]?.type === 'treasureChest') {
+            } else if (MAP.getCell(player.x, player.y)?.type === 'treasureChest') {
                 // Normal chest, provide loot
                 let lootTypeRoll = Math.random();
                 let chestContents;
@@ -10160,10 +9754,7 @@ A Javascript game by <a href="https://milklounge.wang/tardquest/" target="_blank
                 }
 
                 // Remove the chest from the map
-                MAP[player.y][player.x] = new MapCell(
-                    "floor",
-                    { x: player.x, y: player.y }
-                );
+                MAP.setCell(player.x, player.y);
             }
 
             render();
@@ -10298,1052 +9889,860 @@ A Javascript game by <a href="https://milklounge.wang/tardquest/" target="_blank
         playRandomExplorationMusic();
         render();
 
-        const menu = {
-            breadcrumbs: [],
-            selectionIndex: 0,
-            currentPage: 0, // Track the current page for paginated menus
-            getActiveMenu: () => menu.menus[menu.breadcrumbs.at(-1)?.menuName] || undefined,
-            isOpen: () => menu.breadcrumbs.length > 0,
-            open: (menuName) => {
-                if (typeof menu.menus[menuName] === 'undefined') {
-                    console.error('The requested menu does not exist', { menuName });
-                    return;
-                }
+        const menu = new Menu();
+        menu.setMenuElement(document.getElementById("menu"));
+        menu.setDefaultItemsPerPage(8);
+        menu.setOnHighlight(() => playSFX("uiOption"));
+        menu.setOnSelect(() => playSFX("uiSelect"));
+        menu.setOnCancel(() => playSFX("uiCancel"));
 
-                const activeMenu = menu.menus[menuName];
-
-                menu.breadcrumbs.push({
-                    menuName,
-                    selectionIndex: menu.selectionIndex,
-                    currentPage: menu.currentPage,
-                });
-
-                menu.selectionIndex = 0; // Reset selection index
-                menu.currentPage = 0; // Reset to the first page
-
-                document.getElementById('game').classList.add('hidden');
-                document.getElementById('menu').classList.remove('hidden');
-                document.getElementById('menuSelectionDescription').textContent = '';
-
-                activeMenu.onOpen?.();
-                menu.render();
-            },
-            close: () => {
-                const previousMenu = menu.breadcrumbs.pop();
-                if (previousMenu) {
-                    menu.menus[previousMenu.menuName].onClose?.();
-                    menu.selectionIndex = previousMenu.selectionIndex;
-                    menu.currentPage = previousMenu.currentPage;
-                }
-
-                if (menu.breadcrumbs.length === 0) {
-                    document.getElementById('menu').classList.add('hidden');
-                    document.getElementById('game').classList.remove('hidden');
-                }
-            },
-            closeAll: () => {
-                while (menu.breadcrumbs.length > 0) {
-                    const previousMenu = menu.breadcrumbs.pop();
-                    menu.menus[previousMenu.menuName].onClose?.();
-                }
-                document.getElementById('menu').classList.add('hidden');
-                document.getElementById('game').classList.remove('hidden');
-            },
-            highlightOption: (index) => {
-                menu.selectionIndex = index;
-            },
-            render: () => {
-                let menuHtml = "";
-                const activeMenu = menu.getActiveMenu();
-                if (typeof activeMenu === 'undefined') {
-                    return;
-                }
-
-                const options = activeMenu.getOptions();
-                const itemsPerPage = menu.breadcrumbs.at(-1)?.menuName === "statAllocation" ? 12 : 8; // Number of items per stat allocation page : Number of items per every other menu page
-                const totalPages = Math.ceil(options.length / itemsPerPage); // Calculate total pages
-                const startIndex = menu.currentPage * itemsPerPage;
-                const endIndex = startIndex + itemsPerPage;
-                const paginatedOptions = options.slice(startIndex, endIndex);
-
-                // Render the title and page indicator
-                const titleText = typeof activeMenu.title === 'function' ? activeMenu.title() : activeMenu.title;
-                const titleHtml = activeMenu.title ? `<span class="title">「${titleText}」</span>` : '';
-                const landingHtml = `<div>${activeMenu?.landingHtml?.() || ''}</div>`;
-                document.getElementById('menuLanding').innerHTML = titleHtml + landingHtml;
-
-                const paginationText = totalPages > 1 ? (
-                    (menu.currentPage > 0 ? '◀ ' : '  ') +
-                    `Page ${menu.currentPage + 1} of ${totalPages}` +
-                    (menu.currentPage + 1 < totalPages ? ' ▶' : '  ')
-                ) : '';
-
-                menuHtml += `<div id="pageNum">${paginationText}</div>`;
-
-                // Render the options for the current page
-                paginatedOptions.forEach((option, index) => {
-                    const isSelectedLine = index === menu.selectionIndex;
-                    const cursor = isSelectedLine ? "▶ " : "  ";
-                    const spanHtml = "<span " +
-                        `class="option${option.className ? ` ${option.className}` : ""}"` +
-                        `onmouseover="menu.highlightOption(${index}); menu.render();" ` +
-                        `onclick="menu.select(${index});"` +
-                    ">";
-                    const trailText = option.trailText ? `${option.trailText}` : '';
-
-                    const maxLineLength = 56; // Max "." trail width
-                    const dots = trailText
-                        ? '.'.repeat(Math.max(0, maxLineLength - option.displayText.length - trailText.length - 4))
-                        : '';
-
-                    menuHtml +=
-                        `${spanHtml}<span class="cursor">${cursor}</span>` +
-                        `${option.displayText}${dots}${trailText}</span>`;
-
-                    if (isSelectedLine) {
-                        document.getElementById('menuSelectionDescription').textContent = option.description;
+        menu.setMenus({
+            gameSettings: {
+                title: "GAME SETTINGS",
+                onOpen: () => {
+                    Portrait.show('settings');
+                },
+                onClose: () => {
+                    Portrait.hide();
+                },
+                getOptions: () => [
+                    {
+                        id: "_back",
+                        displayText: "Return to the game",
+                        description: "Continue your quest",
+                    },
+                    {
+                        id: "toggleMusic",
+                        displayText: musicEnabled
+                            ? "Disable music"
+                            : "Enable music",
+                        description: musicEnabled
+                            ? "Turn off the in-game music"
+                            : "Turn on the in game music",
+                    },
+                    {
+                        id: "toggleSFX",
+                        displayText: sfxEnabled ? "Disable SFX" : "Enable SFX",
+                        description: sfxEnabled
+                            ? "Disable sound effects"
+                            : "Enable sound effects",
+                    },
+                    {
+                        id: "toggleSpeech",
+                        displayText: speechEnabled ? "Disable speech" : "Enable speech",
+                        description:
+                            `${speechEnabled ? 'Disable' : 'Enable'} the ` +
+                            `party member and NPC speaking voices`,
+                    },
+                    {
+                        id: "toggleSkipTitleScreen",
+                        displayText: skipTitleScreen ? "Disable quickstart" : "Enable quickstart",
+                        description: skipTitleScreen
+                            ? "Skip the title screen automatically upon starting the game"
+                            : "Enable the title screen upon starting the game",
+                    },
+                    {
+                        id: "toggleEatRatAnimation",
+                        displayText: eatRatAnimationEnabled
+                            ? "Disable level up animation"
+                            : "Enable level up animation",
+                        description: eatRatAnimationEnabled
+                            ? "Disable rat consumption animation on level up"
+                            : "Enable rat consumption animation on level up",
+                    },
+                    {
+                        id: "resetGame",
+                        displayText: "Reset the game",
+                        description:
+                            "Abandon your current game and return to the " +
+                            "title screen",
+                    },
+                ],
+                select: (selectedOptionId) => {
+                    switch (selectedOptionId) {
+                        case "toggleMusic":
+                            musicEnabled = !musicEnabled;
+                            saveSettings();
+                            stopAllMusic();
+                            if (musicEnabled) {
+                                player.inCombat
+                                    ? playRandomBattleMusic()
+                                    : (currentExplorationTrack
+                                        ? resumeExplorationMusic()
+                                        : playRandomExplorationMusic()
+                                    );
+                            }
+                            break;
+                        case "toggleSFX":
+                            sfxEnabled = !sfxEnabled;
+                            saveSettings();
+                            break;
+                        case "toggleSpeech":
+                            speechEnabled = !speechEnabled;
+                            saveSettings();
+                            break;
+                        case "toggleSkipTitleScreen":
+                            skipTitleScreen = !skipTitleScreen;
+                            saveSettings();
+                            break;
+                        case "toggleEatRatAnimation":
+                            eatRatAnimationEnabled = !eatRatAnimationEnabled;
+                            saveSettings();
+                            break;
+                        case "resetGame":
+                            menu.open("resetGameConfirmation");
+                            break;
                     }
-                });
-
-                document.getElementById('menuList').innerHTML = menuHtml;
-
-                const $escapeMessage = document.getElementById("escapeMessage");
-                if (activeMenu.escapeDisabled) {
-                    $escapeMessage.classList.add("hidden");
-                } else {
-                    $escapeMessage.classList.remove("hidden");
-                }
+                },
             },
-            getNumberOfItemsPerPage: () =>
-                menu.breadcrumbs.at(-1)?.menuName === "statAllocation" ? 12 : 8,
-            handleInput: (key) => {
-                if (animationActive) return;
-                const activeMenu = menu.getActiveMenu();
-                const options = activeMenu.getOptions();
-                const itemsPerPage = menu.getNumberOfItemsPerPage();
-                const totalPages = Math.ceil(options.length / itemsPerPage);
-                const itemsOnCurrentPage = (menu.currentPage + 1) >= totalPages
-                    ? ((options.length % itemsPerPage) || itemsPerPage)
-                    : itemsPerPage;
-
-                switch (key) {
-                    case 'escape':
-                        menu.goToPreviousMenu();
-                        break;
-                    case 'w':
-                    case 'arrowup':
-                        menu.selectionIndex = menu.selectionIndex <= 0
-                            ? itemsOnCurrentPage - 1
-                            : menu.selectionIndex - 1;
-                        playSFX('uiOption');
-                        break;
-                    case 's':
-                    case 'arrowdown':
-                        menu.selectionIndex = menu.selectionIndex >= itemsOnCurrentPage - 1
-                            ? 0
-                            : menu.selectionIndex + 1;
-                        playSFX('uiOption');
-                        break;
-                    case 'a':
-                    case 'arrowleft':
-                        if (menu.currentPage > 0) {
-                            menu.currentPage--;
-                            menu.selectionIndex = 0; // Reset selection index on page change
-                            playSFX('uiOption');
-                        }
-                        break;
-                    case 'd':
-                    case 'arrowright':
-                        if (menu.currentPage < totalPages - 1) {
-                            menu.currentPage++;
-                            menu.selectionIndex = 0; // Reset selection index on page change
-                            playSFX('uiOption');
-                        }
-                        break;
-                    case ' ':
-                    case 'e':
-                    case 'enter': {
-                        menu.select(menu.selectionIndex);
-                        break;
+            resetGameConfirmation: {
+                title: "RESET GAME",
+                landingHtml: () =>
+                    "Are you sure you want to reset the game?",
+                getOptions: () => [
+                    {
+                        id: "_back",
+                        displayText: "NO! Do not reset the game!",
+                        description: "Go back to the previous menu",
+                    },
+                    {
+                        id: "reset",
+                        displayText: "Yes, waste my progress",
+                        description:
+                            "Abandon the current game and start again " +
+                            "from the first floor",
+                    },
+                ],
+                select: () => window.location.reload(),
+            },
+            inventory: {
+                title: "INVENTORY",
+                landingHtml: () => {
+                    return isEmpty(player.inventory)
+                        ? 'You own nothing. Klaus Schwab would be proud'
+                        : null;
+                },
+                getOptions: () => [
+                    {
+                        id: "inventoryItems",
+                        displayText: "Items",
+                        description: "View your consumable items.",
+                    },
+                    {
+                        id: "inventoryEquipment",
+                        displayText: "Equipment",
+                        description: "View and change your equipped weapon and armor.",
+                    },
+                    {
+                        id: "_back",
+                        displayText: "[Back]",
+                        description: "Get back to playing the game",
                     }
-                }
-
-                menu.render();
-            },
-            goToPreviousMenu: () => {
-                if (menu.getActiveMenu()?.escapeDisabled) {
-                    return;
-                }
-
-                menu.close();
-                playSFX('uiCancel');
-            },
-            select: (index) => {
-                const activeMenu = menu.getActiveMenu();
-                const selectedOptionId =
-                    activeMenu.getOptions()?.
-                        [menu.currentPage * menu.getNumberOfItemsPerPage() + index]?.id;
-                if (selectedOptionId === '_back') {
-                    menu.close();
-                    playSFX('uiCancel');
-                } else if (selectedOptionId === '_exitAll') {
-                    menu.closeAll();
-                    playSFX('uiCancel');
-                } else {
-                    activeMenu?.select(selectedOptionId);
-                    playSFX('uiSelect');
-                }
-            },
-            menus: {
-                gameSettings: {
-                    title: "GAME SETTINGS",
-                    onOpen: () => {
-                        Portrait.show('settings');
-                    },
-                    onClose: () => {
-                        Portrait.hide();
-                    },
-                    getOptions: () => [
-                        {
-                            id: "_back",
-                            displayText: "Return to the game",
-                            description: "Continue your quest",
-                        },
-                        {
-                            id: "toggleMusic",
-                            displayText: musicEnabled
-                                ? "Disable music"
-                                : "Enable music",
-                            description: musicEnabled
-                                ? "Turn off the in-game music"
-                                : "Turn on the in game music",
-                        },
-                        {
-                            id: "toggleSFX",
-                            displayText: sfxEnabled ? "Disable SFX" : "Enable SFX",
-                            description: sfxEnabled
-                                ? "Disable sound effects"
-                                : "Enable sound effects",
-                        },
-                        {
-                            id: "toggleSpeech",
-                            displayText: speechEnabled ? "Disable speech" : "Enable speech",
-                            description:
-                                `${speechEnabled ? 'Disable' : 'Enable'} the ` +
-                                `party member and NPC speaking voices`,
-                        },
-                        {
-                            id: "toggleSkipTitleScreen",
-                            displayText: skipTitleScreen ? "Disable quickstart" : "Enable quickstart",
-                            description: skipTitleScreen
-                                ? "Skip the title screen automatically upon starting the game"
-                                : "Enable the title screen upon starting the game",
-                        },
-                        {
-                            id: "toggleEatRatAnimation",
-                            displayText: eatRatAnimationEnabled
-                                ? "Disable level up animation"
-                                : "Enable level up animation",
-                            description: eatRatAnimationEnabled
-                                ? "Disable rat consumption animation on level up"
-                                : "Enable rat consumption animation on level up",
-                        },
-                        {
-                            id: "resetGame",
-                            displayText: "Reset the game",
-                            description:
-                                "Abandon your current game and return to the " +
-                                "title screen",
-                        },
-                    ],
-                    select: (selectedOptionId) => {
-                        switch (selectedOptionId) {
-                            case "toggleMusic":
-                                musicEnabled = !musicEnabled;
-                                saveSettings();
-                                stopAllMusic();
-                                if (musicEnabled) {
-                                    player.inCombat
-                                        ? playRandomBattleMusic()
-                                        : (currentExplorationTrack
-                                            ? resumeExplorationMusic()
-                                            : playRandomExplorationMusic()
-                                        );
-                                }
-                                break;
-                            case "toggleSFX":
-                                sfxEnabled = !sfxEnabled;
-                                saveSettings();
-                                break;
-                            case "toggleSpeech":
-                                speechEnabled = !speechEnabled;
-                                saveSettings();
-                                break;
-                            case "toggleSkipTitleScreen":
-                                skipTitleScreen = !skipTitleScreen;
-                                saveSettings();
-                                break;
-                            case "toggleEatRatAnimation":
-                                eatRatAnimationEnabled = !eatRatAnimationEnabled;
-                                saveSettings();
-                                break;
-                            case "resetGame":
-                                menu.open("resetGameConfirmation");
-                                break;
-                        }
-                    },
+                ],
+                select: (selectedOptionId) => {
+                    menu.open(selectedOptionId);
                 },
-                resetGameConfirmation: {
-                    title: "RESET GAME",
-                    landingHtml: () =>
-                        "Are you sure you want to reset the game?",
-                    getOptions: () => [
-                        {
-                            id: "_back",
-                            displayText: "NO! Do not reset the game!",
-                            description: "Go back to the previous menu",
-                        },
-                        {
-                            id: "reset",
-                            displayText: "Yes, waste my progress",
-                            description:
-                                "Abandon the current game and start again " +
-                                "from the first floor",
-                        },
-                    ],
-                    select: () => window.location.reload(),
+                onOpen: () => {
+                    Portrait.show('inventory');
                 },
-                inventory: {
-                    title: "INVENTORY",
-                    landingHtml: () => {
-                        return isEmpty(player.inventory)
-                            ? 'You own nothing. Klaus Schwab would be proud'
-                            : null;
-                    },
-                    getOptions: () => [
-                        {
-                            id: "inventoryItems",
-                            displayText: "Items",
-                            description: "View your consumable items.",
-                        },
-                        {
-                            id: "inventoryEquipment",
-                            displayText: "Equipment",
-                            description: "View and change your equipped weapon and armor.",
-                        },
-                        {
-                            id: "_back",
-                            displayText: "[Back]",
-                            description: "Get back to playing the game",
-                        }
-                    ],
-                    select: (selectedOptionId) => {
-                        menu.open(selectedOptionId);
-                    },
-                    onOpen: () => {
-                        Portrait.show('inventory');
-                    },
-                    onClose: () => {
-                        Portrait.hide();
-                    },
+                onClose: () => {
+                    Portrait.hide();
                 },
-                inventoryItems: {
-                    title: "ITEMS",
-                    landingHtml: () => {
-                        return isEmpty(player.inventory)
-                            ? 'You own nothing. Klaus Schwab would be proud'
-                            : null;
-                    },
-                    getOptions: () => {
-                        const options = Object.keys(player.inventory)
-                            .filter(itemId => items[itemId])
-                            .map((itemId) => ({
-                                id: itemId,
-                                displayText: items[itemId].name,
-                                description: items[itemId].description,
-                                trailText: `${player.inventory[itemId]}`,
-                            }));
+            },
+            inventoryItems: {
+                title: "ITEMS",
+                landingHtml: () => {
+                    return isEmpty(player.inventory)
+                        ? 'You own nothing. Klaus Schwab would be proud'
+                        : null;
+                },
+                getOptions: () => {
+                    const options = Object.keys(player.inventory)
+                        .filter(itemId => items[itemId])
+                        .map((itemId) => ({
+                            id: itemId,
+                            displayText: items[itemId].name,
+                            description: items[itemId].description,
+                            trailText: `${player.inventory[itemId]}`,
+                        }));
 
-                        options.push({
+                    options.push({
+                        id: "_back",
+                        displayText: "[Back]",
+                        description: "Return to the inventory menu",
+                    });
+
+                    return options;
+                },
+                select: (selectedOptionId) => {
+                    useItem(selectedOptionId);
+                    menu.closeAll(); // Close all menus after using an item
+                    if (currentEnemy && currentEnemy.hp > 0) {
+                        enemyAttack();
+                        render();
+                    }
+                },
+            },
+            inventoryEquipment: {
+                title: "EQUIPMENT",
+                getOptions: () => {
+                    const weapon = weapons[player.weapon];
+                    const armorPiece = armor[player.armor];
+                    const ring1 = player.ring1 ? rings[player.ring1]?.name : "None";
+                    const ring2 = player.ring2 ? rings[player.ring2]?.name : "None";
+                    return [
+                        {
+                            id: "equipHand",
+                            displayText: `Hand: ${weapon?.name || "None"}`,
+                            description: "View and equip your weapons.",
+                        },
+                        {
+                            id: "equipBody",
+                            displayText: `Body: ${armorPiece?.name || "None"}`,
+                            description: "View and equip your armor.",
+                        },
+                        {
+                            id: "equipRings",
+                            displayText: `Rings: ${ring1}\n         ${ring2}`,
+                            description: "View and equip your rings.",
+                        },
+                        {
                             id: "_back",
                             displayText: "[Back]",
                             description: "Return to the inventory menu",
-                        });
-
-                        return options;
-                    },
-                    select: (selectedOptionId) => {
-                        useItem(selectedOptionId);
-                        menu.closeAll(); // Close all menus after using an item
-                        if (currentEnemy && currentEnemy.hp > 0) {
-                            enemyAttack();
-                            render();
                         }
-                    },
+                    ];
                 },
-                inventoryEquipment: {
-                    title: "EQUIPMENT",
-                    getOptions: () => {
-                        const weapon = weapons[player.weapon];
-                        const armorPiece = armor[player.armor];
-                        const ring1 = player.ring1 ? rings[player.ring1]?.name : "None";
-                        const ring2 = player.ring2 ? rings[player.ring2]?.name : "None";
-                        return [
-                            {
-                                id: "equipHand",
-                                displayText: `Hand: ${weapon?.name || "None"}`,
-                                description: "View and equip your weapons.",
-                            },
-                            {
-                                id: "equipBody",
-                                displayText: `Body: ${armorPiece?.name || "None"}`,
-                                description: "View and equip your armor.",
-                            },
-                            {
-                                id: "equipRings",
-                                displayText: `Rings: ${ring1}\n         ${ring2}`,
-                                description: "View and equip your rings.",
-                            },
-                            {
-                                id: "_back",
-                                displayText: "[Back]",
-                                description: "Return to the inventory menu",
-                            }
-                        ];
-                    },
-                    select: (selectedOptionId) => {
-                        menu.open(selectedOptionId);
-                    },
+                select: (selectedOptionId) => {
+                    menu.open(selectedOptionId);
                 },
-                equipHand: {
-                    title: "EQUIP WEAPON",
-                    getOptions: () => {
-                        const ownedWeapons = Object.keys(weapons).filter(w => player.inventory[w] > 0 || player.weapon === w);
-                        return ownedWeapons.map((weaponId) => {
-                            const req = weapons[weaponId].requiredStr || 0;
-                            const meetsReq = player.strength >= req;
-                            return {
-                                id: weaponId,
-                                displayText: weapons[weaponId].name + (player.weapon === weaponId ? " (Equipped)" : ""),
-                                description:
-                                    `${weapons[weaponId].description}\n` +
-                                    `Base Damage: ${weapons[weaponId].damage.base}, ` +
-                                    `Random Multiplier: ${weapons[weaponId].damage.randomMultiplier}\n` +
-                                    `LOAD: ${weapons[weaponId].weight}\n` +
-                                    `Requires STR: ${req}`,
-                                className: !meetsReq ? "tooExpensive" : (player.weapon === weaponId ? "friendly" : undefined),
-                                disabled: !meetsReq,
-                            };
-                        }).concat([{
+            },
+            equipHand: {
+                title: "EQUIP WEAPON",
+                getOptions: () => {
+                    const ownedWeapons = Object.keys(weapons).filter(w => player.inventory[w] > 0 || player.weapon === w);
+                    return ownedWeapons.map((weaponId) => {
+                        const req = weapons[weaponId].requiredStr || 0;
+                        const meetsReq = player.strength >= req;
+                        return {
+                            id: weaponId,
+                            displayText: weapons[weaponId].name + (player.weapon === weaponId ? " (Equipped)" : ""),
+                            description:
+                                `${weapons[weaponId].description}\n` +
+                                `Base Damage: ${weapons[weaponId].damage.base}, ` +
+                                `Random Multiplier: ${weapons[weaponId].damage.randomMultiplier}\n` +
+                                `LOAD: ${weapons[weaponId].weight}\n` +
+                                `Requires STR: ${req}`,
+                            className: !meetsReq ? "tooExpensive" : (player.weapon === weaponId ? "friendly" : undefined),
+                            disabled: !meetsReq,
+                        };
+                    }).concat([{
+                        id: "_back",
+                        displayText: "[Back]",
+                        description: "Return to equipment menu",
+                    }]);
+                },
+                select: (selectedOptionId) => {
+                    const weapon = weapons[selectedOptionId];
+                    if (!weapon) return;
+                    const req = weapon.requiredStr || 0;
+                    if (player.strength < req) {
+                        updateBattleLog(`You require <span class="STR">${req} STR</span> to handle this weapon!`);
+                        return;
+                    }
+                    player.weapon = selectedOptionId;
+                    updateBattleLog(`You now wield a mighty <span class="friendly">${weapon.name}</span>!`);
+                    menu.close();
+                    render();
+                },
+            },
+
+            equipBody: {
+                title: "EQUIP ARMOR",
+                getOptions: () => {
+                    const ownedArmor = Object.keys(armor).filter(a => player.inventory[a] > 0 || player.armor === a);
+                    return ownedArmor.map((armorId) => {
+                        const req = armor[armorId].requiredEnd || 0;
+                        const meetsReq = player.endurance >= req;
+                        return {
+                            id: armorId,
+                            displayText: armor[armorId].name + (player.armor === armorId ? " (Equipped)" : ""),
+                            description:
+                                `${armor[armorId].description}\n` +
+                                `Defense: ${armor[armorId].defense}\n` +
+                                `LOAD: ${armor[armorId].weight}\n` +
+                                `Requires END: ${req}`,
+                            className: !meetsReq ? "tooExpensive" : (player.armor === armorId ? "friendly" : undefined),
+                            disabled: !meetsReq,
+                        };
+                    }).concat([{
+                        id: "_back",
+                        displayText: "[Back]",
+                        description: "Return to equipment menu",
+                    }]);
+                },
+                select: (selectedOptionId) => {
+                    const armorPiece = armor[selectedOptionId];
+                    if (!armorPiece) return;
+                    const req = armorPiece.requiredEnd || 0;
+                    if (player.endurance < req) {
+                        updateBattleLog(`You need <span class="END">${req} END</span> to wear this garment!`);
+                        return;
+                    }
+                    player.armor = selectedOptionId;
+                    updateBattleLog(
+                        `You are now wearing ${armorPiece.article} ` +
+                        `<span class="friendly">${armorPiece.name}</span>!`
+                    );
+                    if (player.hp > getEffectiveStat('maxHp')) {
+                        player.hp = getEffectiveStat('maxHp');
+                    }
+                    menu.close();
+                    render();
+                },
+            },
+            equipRings: {
+                title: "EQUIP RINGS",
+                getOptions: () => {
+                    return [
+                        {
+                            id: "ring1",
+                            displayText: `Slot 1: ${player.ring1 ? rings[player.ring1].name + " (Equipped)" : "None"}`,
+                            description: "Equip a ring to Slot 1.",
+                            className: "friendly"
+                        },
+                        {
+                            id: "ring2",
+                            displayText: `Slot 2: ${player.ring2 ? rings[player.ring2].name + " (Equipped)" : "None"}`,
+                            description: "Equip a ring to Slot 2.",
+                            className: "friendly"
+                        },
+                        {
                             id: "_back",
                             displayText: "[Back]",
                             description: "Return to equipment menu",
-                        }]);
-                    },
-                    select: (selectedOptionId) => {
-                        const weapon = weapons[selectedOptionId];
-                        if (!weapon) return;
-                        const req = weapon.requiredStr || 0;
-                        if (player.strength < req) {
-                            updateBattleLog(`You require <span class="STR">${req} STR</span> to handle this weapon!`);
-                            return;
                         }
-                        player.weapon = selectedOptionId;
-                        updateBattleLog(`You now wield a mighty <span class="friendly">${weapon.name}</span>!`);
-                        menu.close();
-                        render();
-                    },
+                    ];
                 },
-
-                equipBody: {
-                    title: "EQUIP ARMOR",
-                    getOptions: () => {
-                        const ownedArmor = Object.keys(armor).filter(a => player.inventory[a] > 0 || player.armor === a);
-                        return ownedArmor.map((armorId) => {
-                            const req = armor[armorId].requiredEnd || 0;
-                            const meetsReq = player.endurance >= req;
-                            return {
-                                id: armorId,
-                                displayText: armor[armorId].name + (player.armor === armorId ? " (Equipped)" : ""),
-                                description:
-                                    `${armor[armorId].description}\n` +
-                                    `Defense: ${armor[armorId].defense}\n` +
-                                    `LOAD: ${armor[armorId].weight}\n` +
-                                    `Requires END: ${req}`,
-                                className: !meetsReq ? "tooExpensive" : (player.armor === armorId ? "friendly" : undefined),
-                                disabled: !meetsReq,
-                            };
-                        }).concat([{
-                            id: "_back",
-                            displayText: "[Back]",
-                            description: "Return to equipment menu",
-                        }]);
-                    },
-                    select: (selectedOptionId) => {
-                        const armorPiece = armor[selectedOptionId];
-                        if (!armorPiece) return;
-                        const req = armorPiece.requiredEnd || 0;
-                        if (player.endurance < req) {
-                            updateBattleLog(`You need <span class="END">${req} END</span> to wear this garment!`);
-                            return;
-                        }
-                        player.armor = selectedOptionId;
-                        updateBattleLog(
-                            `You are now wearing ${armorPiece.article} ` +
-                            `<span class="friendly">${armorPiece.name}</span>!`
-                        );
+                select: (selectedOptionId) => {
+                    if (selectedOptionId === "ring1") {
+                        menu.open("ring1Select");
+                    } else if (selectedOptionId === "ring2") {
+                        menu.open("ring2Select");
+                    } else {
                         if (player.hp > getEffectiveStat('maxHp')) {
                             player.hp = getEffectiveStat('maxHp');
                         }
                         menu.close();
                         render();
-                    },
+                    }
                 },
-                equipRings: {
-                    title: "EQUIP RINGS",
-                    getOptions: () => {
-                        return [
-                            {
-                                id: "ring1",
-                                displayText: `Slot 1: ${player.ring1 ? rings[player.ring1].name + " (Equipped)" : "None"}`,
-                                description: "Equip a ring to Slot 1.",
-                                className: "friendly"
-                            },
-                            {
-                                id: "ring2",
-                                displayText: `Slot 2: ${player.ring2 ? rings[player.ring2].name + " (Equipped)" : "None"}`,
-                                description: "Equip a ring to Slot 2.",
-                                className: "friendly"
-                            },
-                            {
-                                id: "_back",
-                                displayText: "[Back]",
-                                description: "Return to equipment menu",
-                            }
-                        ];
-                    },
-                    select: (selectedOptionId) => {
-                        if (selectedOptionId === "ring1") {
-                            menu.open("ring1Select");
-                        } else if (selectedOptionId === "ring2") {
-                            menu.open("ring2Select");
-                        } else {
-                            if (player.hp > getEffectiveStat('maxHp')) {
-                                player.hp = getEffectiveStat('maxHp');
-                            }
-                            menu.close();
-                            render();
-                        }
-                    },
+            },
+            ring1Select: {
+                title: "EQUIP RING 1",
+                getOptions: () => {
+                    const ownedRings = Object.keys(rings).filter(r => player.inventory[r] > 0 || player.ring1 === r || player.ring2 === r);
+                    const options = ownedRings.map((ringId) => ({
+                        id: ringId,
+                        displayText: rings[ringId].name + (player.ring1 === ringId ? " (Equipped)" : ""),
+                        description: rings[ringId].description,
+                        className: player.ring1 === ringId
+                            ? "friendly"
+                            : player.ring2 === ringId
+                                ? "muted"
+                                : undefined,
+                    }));
+                    options.unshift({
+                        id: null,
+                        displayText: "None",
+                        description: "Unequip this ring slot.",
+                    });
+                    options.push({
+                        id: "_back",
+                        displayText: "[Back]",
+                        description: "Return to rings menu",
+                    });
+                    return options;
                 },
-                ring1Select: {
-                    title: "EQUIP RING 1",
-                    getOptions: () => {
-                        const ownedRings = Object.keys(rings).filter(r => player.inventory[r] > 0 || player.ring1 === r || player.ring2 === r);
-                        const options = ownedRings.map((ringId) => ({
-                            id: ringId,
-                            displayText: rings[ringId].name + (player.ring1 === ringId ? " (Equipped)" : ""),
-                            description: rings[ringId].description,
-                            className: player.ring1 === ringId
-                                ? "friendly"
-                                : player.ring2 === ringId
-                                    ? "muted"
-                                    : undefined,
-                        }));
-                        options.unshift({
-                            id: null,
-                            displayText: "None",
-                            description: "Unequip this ring slot.",
-                        });
-                        options.push({
-                            id: "_back",
-                            displayText: "[Back]",
-                            description: "Return to rings menu",
-                        });
-                        return options;
-                    },
-                    select: (selectedOptionId) => {
-                        if (player.equipRing(1, selectedOptionId)) {
-                            menu.close();
-                            render();
-                        }
-                    },
-                },
-
-                ring2Select: {
-                    title: "EQUIP RING 2",
-                    getOptions: () => {
-                        const ownedRings = Object.keys(rings).filter(r => player.inventory[r] > 0 || player.ring1 === r || player.ring2 === r);
-                        const options = ownedRings.map((ringId) => ({
-                            id: ringId,
-                            displayText: rings[ringId].name + (player.ring2 === ringId ? " (Equipped)" : ""),
-                            description: rings[ringId].description,
-                            className: player.ring2 === ringId
-                                ? "friendly"
-                                : player.ring1 === ringId
-                                    ? "muted"
-                                    : undefined,
-                        }));
-                        options.unshift({
-                            id: null,
-                            displayText: "None",
-                            description: "Unequip this ring slot.",
-                        });
-                        options.push({
-                            id: "_back",
-                            displayText: "[Back]",
-                            description: "Return to rings menu",
-                        });
-                        return options;
-                    },
-                    select: (selectedOptionId) => {
-                        if (player.equipRing(2, selectedOptionId)) {
-                            menu.close();
-                            render();
-                        }
-                    },
-                },
-
-                merchant: {
-                    title: "MERCHANT",
-                    onOpen: () => {
-                        Portrait.show('merchant');
-                        merchant.say('Welcome to SlobMart!');
-                    },
-                    onClose: () => {
-                        merchant.say('Thank you. Come again!');
-                        Portrait.hide();
-                    },
-                    landingHtml: () => {
-                        return player.bitcoins > 0
-                            ? `You have <span class="BTC">${player.bitcoins} BTC</span> in your wallet`
-                            : "Your wallet is emptier than a lughead's skull. But you can still look around";
-                    },
-                    getOptions: () => {
-                        return [
-                            {
-                                id: "merchantItems",
-                                displayText: "Items",
-                                description: "See what consumable items are for sale",
-                            },
-                            {
-                                id: "merchantWeapons",
-                                displayText: "Weapons",
-                                description: "Look at some weapon upgrades",
-                            },
-                            {
-                                id: "merchantArmor",
-                                displayText: "Armor",
-                                description: "Get some thicker skin",
-                            },
-                            {
-                                id: "merchantRings",
-                                displayText: "Rings",
-                                description: "Jewelry that will probably turn you gay",
-                            },
-                            {
-                                id: "merchantSell",
-                                displayText: "Sell",
-                                description: "Sell your items, filthy garb, and dangerous arms",
-                            },
-                            {
-                                id: "_back",
-                                displayText: "Leave",
-                                description: "Get back to spelunking",
-                            },
-                        ];
-                    },
-                    select: (selectedOptionId) => {
-                        menu.open(selectedOptionId);
-                    },
-                },
-                merchantItems: {
-                    title: "MERCHANT",
-                    landingHtml: () => {
-                        return player.bitcoins > 0
-                            ? `You have <span class="BTC">${player.bitcoins} BTC</span> in your wallet`
-                            : "Your wallet is emptier than a lughead's skull. But you can still look around";
-                    },
-                    getOptions: () => {
-                        const options = merchant.items.map((itemId) => ({
-                            id: itemId,
-                            displayText: items[itemId].name,
-                            description: items[itemId].description,
-                            trailText: `${items[itemId].price} BTC`,
-                            disabled: items[itemId].price > player.bitcoins,
-                            className: items[itemId].price > player.bitcoins ? 'tooExpensive' : undefined,
-                        }));
-
-                        options.push({
-                            id: "_back",
-                            displayText: "Back",
-                            description: "Return to the merchant menu",
-                        });
-
-                        return options;
-                    },
-                    select: (selectedOptionId) => {
-                        merchant.buy('item', selectedOptionId);
-                    },
-                },
-                merchantWeapons: {
-                    title: "MERCHANT",
-                    landingHtml: () => {
-                        const message = player.bitcoins > 0
-                            ? `You have <span class="BTC">${player.bitcoins} BTC</span> in your wallet`
-                            : "Your wallet is emptier than a lughead's skull. But you can still look around";
-
-                        const currentWeapon = weapons[player.weapon];
-                        const article =
-                            currentWeapon?.article ? `${currentWeapon.article} ` : '';
-                        const currentWeaponDisplay = article + currentWeapon.name;
-                        const wieldingMessage = `You are currently wielding ${currentWeaponDisplay}`;
-
-                        return `${message}\n\n${wieldingMessage}`;
-                    },
-                    getOptions: () => {
-                        const weaponKeys = Object.keys(weapons);
-                        const options = weaponKeys.map((weaponId) => {
-                            const tooExpensive = weapons[weaponId].price > player.bitcoins;
-                            const alreadyOwned = player.inventory[weaponId] > 0 || player.weapon === weaponId;
-                            const reqStr = weapons[weaponId].requiredStr || 0;
-                            return {
-                                id: weaponId,
-                                displayText: weapons[weaponId].name,
-                                description:
-                                    `${weapons[weaponId].description}\n` +
-                                    `Base Damage: ${weapons[weaponId].damage.base}, ` +
-                                    `Random Multiplier: ${weapons[weaponId].damage.randomMultiplier}\n` +
-                                    `LOAD: ${weapons[weaponId].weight}\n` +
-                                    `Stat Requirement: STR ${reqStr}`,
-                                trailText: `${weapons[weaponId].price} BTC`,
-                                disabled: tooExpensive || alreadyOwned,
-                                className: alreadyOwned ? 'muted' : (tooExpensive ? 'tooExpensive' : undefined),
-                            };
-                        });
-
-                        options.push({
-                            id: "_back",
-                            displayText: "Back",
-                            description: "Return to the merchant menu",
-                        });
-
-                        return options;
-                    },
-                    select: (selectedOptionId) => {
-                        merchant.buy('weapon', selectedOptionId);
-                    },
-                },
-                merchantArmor: {
-                    title: "MERCHANT",
-                    landingHtml: () => {
-                        const message = player.bitcoins > 0
-                            ? `You have <span class="BTC">${player.bitcoins} BTC</span> in your wallet`
-                            : "Your wallet is emptier than a lughead's skull. But you can still look around";
-
-                        const currentArmor = armor[player.armor];
-                        const article =
-                            currentArmor?.article ? `${currentArmor.article} ` : '';
-                        const currentArmorDisplay = article + currentArmor.name;
-                        const wearingMessage = `You are currently wearing ${currentArmorDisplay}`;
-
-                        return `${message}\n\n${wearingMessage}`;
-                    },
-                    getOptions: () => {
-                        const armorKeys = Object.keys(armor);
-                        const options = armorKeys.map((armorId) => {
-                            const tooExpensive = armor[armorId].price > player.bitcoins;
-                            const alreadyOwned = player.inventory[armorId] > 0 || player.armor === armorId;
-                            const reqEnd = armor[armorId].requiredEnd || 0;
-                            return {
-                                id: armorId,
-                                displayText: armor[armorId].name,
-                                description:
-                                    `${armor[armorId].description}\n` +
-                                    `Defense: ${armor[armorId].defense}\n` +
-                                    `LOAD: ${armor[armorId].weight}\n` +
-                                    `Stat Requirement: END ${reqEnd}`,
-                                trailText: `${armor[armorId].price} BTC`,
-                                disabled: tooExpensive || alreadyOwned,
-                                className: alreadyOwned ? 'muted' : (tooExpensive ? 'tooExpensive' : undefined),
-                            };
-                        });
-
-                        options.push({
-                            id: "_back",
-                            displayText: "Back",
-                            description: "Return to the merchant menu",
-                        });
-
-                        return options;
-                    },
-                    select: (selectedOptionId) => {
-                        merchant.buy('armor', selectedOptionId);
-                    },
-                },
-                merchantRings: {
-                    title: "RINGS",
-                    landingHtml: () => {
-                        return player.bitcoins > 0
-                            ? `You have <span class="BTC">${player.bitcoins} BTC</span> in your wallet`
-                            : "Your wallet is emptier than a lughead's skull. But you can still look around";
-                    },
-                    getOptions: () => {
-                        const options = (merchant.rings || []).map((ringId) => {
-                            const tooExpensive = rings[ringId].price > player.bitcoins;
-                            const alreadyOwned = player.inventory[ringId] > 0 || player.ring1 === ringId || player.ring2 === ringId;
-                            return {
-                                id: ringId,
-                                displayText: rings[ringId].name,
-                                description: rings[ringId].description,
-                                trailText: `${rings[ringId].price} BTC`,
-                                disabled: tooExpensive || alreadyOwned,
-                                className: alreadyOwned ? 'muted' : (tooExpensive ? 'tooExpensive' : undefined),
-                            };
-                        });
-
-                        options.push({
-                            id: "_back",
-                            displayText: "Back",
-                            description: "Return to the merchant menu",
-                        });
-
-                        return options;
-                    },
-                    select: (selectedOptionId) => {
-                        // Buy logic for rings
-                        merchant.buy('ring', selectedOptionId);
-                        render();
-                        menu.render();
-                    },
-                },
-
-                merchantSell: {
-                    title: "SELL",
-                    landingHtml: () => {
-                        return `Sell your unwanted inventory for a small sum.\n\nYou have <span class="BTC">${player.bitcoins} BTC</span> in your wallet.`;
-                    },
-                    getOptions: () => {
-                        const weaponOptions = Object.keys(weapons)
-                            .filter(w => player.inventory[w] > 0)
-                            .map(weaponId => ({
-                                id: `sell_weapon_${weaponId}`,
-                                displayText: `[W] ${weapons[weaponId].name}`,
-                                description: `Sell for ${Math.max(1, Math.floor(weapons[weaponId].price / 10))} BTC`,
-                                trailText: `${player.inventory[weaponId]}`,
-                                disabled: player.weapon === weaponId,
-                                className: player.weapon === weaponId ? "muted" : undefined,
-                            }));
-                        const armorOptions = Object.keys(armor)
-                            .filter(a => player.inventory[a] > 0)
-                            .map(armorId => ({
-                                id: `sell_armor_${armorId}`,
-                                displayText: `[A] ${armor[armorId].name}`,
-                                description: `Sell for ${Math.max(1, Math.floor(armor[armorId].price / 10))} BTC`,
-                                trailText: `${player.inventory[armorId]}`,
-                                disabled: player.armor === armorId,
-                                className: player.armor === armorId ? "muted" : undefined,
-                            }));
-                        const itemOptions = Object.keys(items)
-                            .filter(itemId => player.inventory[itemId] > 0)
-                            .map(itemId => ({
-                                id: `sell_item_${itemId}`,
-                                displayText: `[I] ${items[itemId].name}`,
-                                description: `Sell for ${Math.max(1, Math.floor(items[itemId].price / 5))} BTC`,
-                                trailText: `${player.inventory[itemId]}`,
-                                disabled: false,
-                                className: undefined,
-                            }));
-                        const ringOptions = Object.keys(rings)
-                            .filter(ringId => player.inventory[ringId] > 0)
-                            .map(ringId => ({
-                                id: `sell_ring_${ringId}`,
-                                displayText: `[R] ${rings[ringId].name}`,
-                                description: `Sell for ${Math.max(1, Math.floor(rings[ringId].price / 5))} BTC`,
-                                trailText: `${player.inventory[ringId]}`,
-                                disabled: player.ring1 === ringId || player.ring2 === ringId,
-                                className: (player.ring1 === ringId || player.ring2 === ringId) ? "muted" : undefined,
-                            }));
-
-                        const options = [...weaponOptions, ...armorOptions, ...ringOptions, ...itemOptions];
-                        if (options.length === 0) {
-                            options.push({
-                                id: "_none",
-                                displayText: "Nothing to sell",
-                                description: "You have no weapons, armor, or items to sell.",
-                                disabled: true,
-                                className: "muted",
-                            });
-                        }
-                        options.push({
-                            id: "_back",
-                            displayText: "[Back]",
-                            description: "Return to the merchant menu",
-                        });
-                        return options;
-                    },
-                    select: (selectedOptionId) => {
-                        if (selectedOptionId === "_back" || selectedOptionId === "_none") {
-                            menu.close();
-                            return;
-                        }
-
-                        const [_, type, itemId] = selectedOptionId.split("_");
-                        let soldObject, value = 0;
-
-                        if (type === "weapon") {
-                            if (player.weapon === itemId) {
-                                merchant.say("You sure you wanna point that thing at me? I've got a 12 gauge hidden under my sleeve, you know...");
-                                return;
-                            }
-                            if (player.inventory[itemId] > 0) {
-                                soldObject = weapons[itemId];
-                                value = merchant.getSalePrice('weapon', weapons[itemId].price);
-                                player.giveBitcoins(value);
-                                player.inventory[itemId]--;
-                                if (player.inventory[itemId] <= 0) delete player.inventory[itemId];
-                            } else {
-                                console.error("Tried to sell an item that the player does not have", { itemId });
-                                return;
-                            }
-                        } else if (type === "armor") {
-                            if (player.armor === itemId) {
-                                merchant.say("What are you, a Lughead? You gotta strip down before you go selling that!");
-                                return;
-                            }
-                            if (player.inventory[itemId] > 0) {
-                                soldObject = armor[itemId];
-                                value = merchant.getSalePrice('armor', armor[itemId].price);
-                                player.giveBitcoins(value);
-                                player.inventory[itemId]--;
-                                if (player.inventory[itemId] <= 0) delete player.inventory[itemId];
-                            } else {
-                                console.error("Tried to sell armor that the player does not have", { itemId });
-                                return;
-                            }
-                        } else if (type === "ring") {
-                            if (player.hasEquippedRing(itemId)) {
-                                merchant.say("I don't swing that way, kid, but if you really wanna propose you gotta take the damn ring off.");
-                                return;
-                            }
-                            if (player.inventory[itemId] > 0) {
-                                soldObject = rings[itemId];
-                                value = merchant.getSalePrice('ring', rings[itemId].price);
-                                player.giveBitcoins(value);
-                                player.inventory[itemId]--;
-                                if (player.inventory[itemId] <= 0) delete player.inventory[itemId];
-                            } else {
-                                console.error("Tried to sell a ring that the player does not have", { itemId });
-                                return;
-                            }
-                        } else if (type === "item") {
-                            if (player.inventory[itemId] > 0) {
-                                soldObject = items[itemId];
-                                value = merchant.getSalePrice('item', items[itemId].price);
-                                player.giveBitcoins(value);
-                                player.inventory[itemId]--;
-                                if (player.inventory[itemId] <= 0) delete player.inventory[itemId];
-                            } else {
-                                console.error("Tried to sell an item that the player does not have", { itemId });
-                                return;
-                            }
-                        }
-
-                        playSFX('kaching');
-                        merchant.printTransactionMessage('sold', soldObject, value);
-                        menu.render();
-                        render();
-                    },
-                },
-
-                gambler: {
-                    title: "GAMBLER",
-                    onOpen: () => {
-                        Portrait.show('gambler');
-                        gambler.say('Place yer bets!');
-                    },
-                    onClose: () => {
-                        gambler.isActiveOnFloor = false;
-                        const gamblerPosition = gambler.location();
-                        if (gamblerPosition) {
-                            MAP[gamblerPosition.y][gamblerPosition.x] =
-                                new MapCell(
-                                    "floor",
-                                    { x: gamblerPosition.x, y: gamblerPosition.y }
-                                );
-                        }
-                        Portrait.hide();
-                    },
-                    landingHtml: () => {
-                        return (
-                            `<span class="gambler">&lt;GAMBLER&gt;</span> "Welcome, dungeon dweller! ` +
-                            `<span class="friendly">Roll a 12</span> and <span class="BTC">boost one of yer stats.</span> ` +
-                            `Just <span class="tooExpensive">${gambler.playPrice}</span> to play!"\n\n` +
-                            `You have <span class="BTC">${player.bitcoins} BTC</span> in your wallet`
-                        );
-                    },
-                    getOptions: () => {
-                        return [
-                            {
-                                id: "play",
-                                displayText: "Play the game",
-                                trailText: `${gambler.playPrice} BTC`,
-                                description: "Take your chance with the gambler",
-                            },
-                            {
-                                id: "_back",
-                                displayText: "Leave",
-                                description: "Leave this crusty fool",
-                            },
-                        ];
-                    },
-                    select: () => {
-                        gamble();
-                    },
-                },
-                chest: {
-                    title: "TREASURE CHEST",
-                    onOpen: () => {
-                        Portrait.show('chest');
-                    },
-                    onClose: () => {
-                        Portrait.hide();
-                    },
-                    landingHtml: () => {
-                        return `\n\n\nYou found a treasure chest! Do you want to open it?`;
-                    },
-                    getOptions: () => {
-                        return [
-                            {
-                                id: "open",
-                                displayText: "Hell yeah! Fondle that booty!",
-                                description: "Claim your succulent reward!",
-                            },
-                            {
-                                id: "_back",
-                                displayText: "Resist your burning temptation...",
-                                description: "DON'T claim your succulent reward!",
-                            },
-                        ];
-                    },
-                    select: (selectedOptionId) => {
-                        if (selectedOptionId === "open") {
-                            openChest();
-                        }
+                select: (selectedOptionId) => {
+                    if (player.equipRing(1, selectedOptionId)) {
                         menu.close();
                         render();
-                    },
+                    }
                 },
-                statAllocation: {
-                    // Prevent menu from being closed with the Escape key
-                    escapeDisabled: true,
-                    title: () => isLevelUpAllocation ? "LEVEL UP" : "STAT ALLOCATION",
-                    landingHtml: () => {
-                        return isLevelUpAllocation
-                            ? `You leveled up! Allocate <span class="action">${player.remainingPoints}</span> points to your stats.`
-                            : `Build your character using the <span class="action">${player.remainingPoints}</span> points you have been allotted. Use them wisely...`;
-                    },
-                    getOptions: () => {
+            },
+
+            ring2Select: {
+                title: "EQUIP RING 2",
+                getOptions: () => {
+                    const ownedRings = Object.keys(rings).filter(r => player.inventory[r] > 0 || player.ring1 === r || player.ring2 === r);
+                    const options = ownedRings.map((ringId) => ({
+                        id: ringId,
+                        displayText: rings[ringId].name + (player.ring2 === ringId ? " (Equipped)" : ""),
+                        description: rings[ringId].description,
+                        className: player.ring2 === ringId
+                            ? "friendly"
+                            : player.ring1 === ringId
+                                ? "muted"
+                                : undefined,
+                    }));
+                    options.unshift({
+                        id: null,
+                        displayText: "None",
+                        description: "Unequip this ring slot.",
+                    });
+                    options.push({
+                        id: "_back",
+                        displayText: "[Back]",
+                        description: "Return to rings menu",
+                    });
+                    return options;
+                },
+                select: (selectedOptionId) => {
+                    if (player.equipRing(2, selectedOptionId)) {
+                        menu.close();
+                        render();
+                    }
+                },
+            },
+
+            merchant: {
+                title: "MERCHANT",
+                onOpen: () => {
+                    Portrait.show('merchant');
+                    merchant.say('Welcome to SlobMart!');
+                },
+                onClose: () => {
+                    merchant.say('Thank you. Come again!');
+                    Portrait.hide();
+                },
+                landingHtml: () => {
+                    return player.bitcoins > 0
+                        ? `You have <span class="BTC">${player.bitcoins} BTC</span> in your wallet`
+                        : "Your wallet is emptier than a lughead's skull. But you can still look around";
+                },
+                getOptions: () => {
+                    return [
+                        {
+                            id: "merchantItems",
+                            displayText: "Items",
+                            description: "See what consumable items are for sale",
+                        },
+                        {
+                            id: "merchantWeapons",
+                            displayText: "Weapons",
+                            description: "Look at some weapon upgrades",
+                        },
+                        {
+                            id: "merchantArmor",
+                            displayText: "Armor",
+                            description: "Get some thicker skin",
+                        },
+                        {
+                            id: "merchantRings",
+                            displayText: "Rings",
+                            description: "Jewelry that will probably turn you gay",
+                        },
+                        {
+                            id: "merchantSell",
+                            displayText: "Sell",
+                            description: "Sell your items, filthy garb, and dangerous arms",
+                        },
+                        {
+                            id: "_back",
+                            displayText: "Leave",
+                            description: "Get back to spelunking",
+                        },
+                    ];
+                },
+                select: (selectedOptionId) => {
+                    menu.open(selectedOptionId);
+                },
+            },
+            merchantItems: {
+                title: "MERCHANT",
+                landingHtml: () => {
+                    return player.bitcoins > 0
+                        ? `You have <span class="BTC">${player.bitcoins} BTC</span> in your wallet`
+                        : "Your wallet is emptier than a lughead's skull. But you can still look around";
+                },
+                getOptions: () => {
+                    const options = merchant.items.map((itemId) => ({
+                        id: itemId,
+                        displayText: items[itemId].name,
+                        description: items[itemId].description,
+                        trailText: `${items[itemId].price} BTC`,
+                        disabled: items[itemId].price > player.bitcoins,
+                        className: items[itemId].price > player.bitcoins ? 'tooExpensive' : undefined,
+                    }));
+
+                    options.push({
+                        id: "_back",
+                        displayText: "Back",
+                        description: "Return to the merchant menu",
+                    });
+
+                    return options;
+                },
+                select: (selectedOptionId) => {
+                    merchant.buy('item', selectedOptionId);
+                },
+            },
+            merchantWeapons: {
+                title: "MERCHANT",
+                landingHtml: () => {
+                    const message = player.bitcoins > 0
+                        ? `You have <span class="BTC">${player.bitcoins} BTC</span> in your wallet`
+                        : "Your wallet is emptier than a lughead's skull. But you can still look around";
+
+                    const currentWeapon = weapons[player.weapon];
+                    const article =
+                        currentWeapon?.article ? `${currentWeapon.article} ` : '';
+                    const currentWeaponDisplay = article + currentWeapon.name;
+                    const wieldingMessage = `You are currently wielding ${currentWeaponDisplay}`;
+
+                    return `${message}\n\n${wieldingMessage}`;
+                },
+                getOptions: () => {
+                    const weaponKeys = Object.keys(weapons);
+                    const options = weaponKeys.map((weaponId) => {
+                        const tooExpensive = weapons[weaponId].price > player.bitcoins;
+                        const alreadyOwned = player.inventory[weaponId] > 0 || player.weapon === weaponId;
+                        const reqStr = weapons[weaponId].requiredStr || 0;
+                        return {
+                            id: weaponId,
+                            displayText: weapons[weaponId].name,
+                            description:
+                                `${weapons[weaponId].description}\n` +
+                                `Base Damage: ${weapons[weaponId].damage.base}, ` +
+                                `Random Multiplier: ${weapons[weaponId].damage.randomMultiplier}\n` +
+                                `LOAD: ${weapons[weaponId].weight}\n` +
+                                `Stat Requirement: STR ${reqStr}`,
+                            trailText: `${weapons[weaponId].price} BTC`,
+                            disabled: tooExpensive || alreadyOwned,
+                            className: alreadyOwned ? 'muted' : (tooExpensive ? 'tooExpensive' : undefined),
+                        };
+                    });
+
+                    options.push({
+                        id: "_back",
+                        displayText: "Back",
+                        description: "Return to the merchant menu",
+                    });
+
+                    return options;
+                },
+                select: (selectedOptionId) => {
+                    merchant.buy('weapon', selectedOptionId);
+                },
+            },
+            merchantArmor: {
+                title: "MERCHANT",
+                landingHtml: () => {
+                    const message = player.bitcoins > 0
+                        ? `You have <span class="BTC">${player.bitcoins} BTC</span> in your wallet`
+                        : "Your wallet is emptier than a lughead's skull. But you can still look around";
+
+                    const currentArmor = armor[player.armor];
+                    const article =
+                        currentArmor?.article ? `${currentArmor.article} ` : '';
+                    const currentArmorDisplay = article + currentArmor.name;
+                    const wearingMessage = `You are currently wearing ${currentArmorDisplay}`;
+
+                    return `${message}\n\n${wearingMessage}`;
+                },
+                getOptions: () => {
+                    const armorKeys = Object.keys(armor);
+                    const options = armorKeys.map((armorId) => {
+                        const tooExpensive = armor[armorId].price > player.bitcoins;
+                        const alreadyOwned = player.inventory[armorId] > 0 || player.armor === armorId;
+                        const reqEnd = armor[armorId].requiredEnd || 0;
+                        return {
+                            id: armorId,
+                            displayText: armor[armorId].name,
+                            description:
+                                `${armor[armorId].description}\n` +
+                                `Defense: ${armor[armorId].defense}\n` +
+                                `LOAD: ${armor[armorId].weight}\n` +
+                                `Stat Requirement: END ${reqEnd}`,
+                            trailText: `${armor[armorId].price} BTC`,
+                            disabled: tooExpensive || alreadyOwned,
+                            className: alreadyOwned ? 'muted' : (tooExpensive ? 'tooExpensive' : undefined),
+                        };
+                    });
+
+                    options.push({
+                        id: "_back",
+                        displayText: "Back",
+                        description: "Return to the merchant menu",
+                    });
+
+                    return options;
+                },
+                select: (selectedOptionId) => {
+                    merchant.buy('armor', selectedOptionId);
+                },
+            },
+            merchantRings: {
+                title: "RINGS",
+                landingHtml: () => {
+                    return player.bitcoins > 0
+                        ? `You have <span class="BTC">${player.bitcoins} BTC</span> in your wallet`
+                        : "Your wallet is emptier than a lughead's skull. But you can still look around";
+                },
+                getOptions: () => {
+                    const options = (merchant.rings || []).map((ringId) => {
+                        const tooExpensive = rings[ringId].price > player.bitcoins;
+                        const alreadyOwned = player.inventory[ringId] > 0 || player.ring1 === ringId || player.ring2 === ringId;
+                        return {
+                            id: ringId,
+                            displayText: rings[ringId].name,
+                            description: rings[ringId].description,
+                            trailText: `${rings[ringId].price} BTC`,
+                            disabled: tooExpensive || alreadyOwned,
+                            className: alreadyOwned ? 'muted' : (tooExpensive ? 'tooExpensive' : undefined),
+                        };
+                    });
+
+                    options.push({
+                        id: "_back",
+                        displayText: "Back",
+                        description: "Return to the merchant menu",
+                    });
+
+                    return options;
+                },
+                select: (selectedOptionId) => {
+                    // Buy logic for rings
+                    merchant.buy('ring', selectedOptionId);
+                    render();
+                    menu.render();
+                },
+            },
+
+            merchantSell: {
+                title: "SELL",
+                landingHtml: () => {
+                    return `Sell your unwanted inventory for a small sum.\n\nYou have <span class="BTC">${player.bitcoins} BTC</span> in your wallet.`;
+                },
+                getOptions: () => {
+                    const weaponOptions = Object.keys(weapons)
+                        .filter(w => player.inventory[w] > 0)
+                        .map(weaponId => ({
+                            id: `sell_weapon_${weaponId}`,
+                            displayText: `[W] ${weapons[weaponId].name}`,
+                            description: `Sell for ${Math.max(1, Math.floor(weapons[weaponId].price / 10))} BTC`,
+                            trailText: `${player.inventory[weaponId]}`,
+                            disabled: player.weapon === weaponId,
+                            className: player.weapon === weaponId ? "muted" : undefined,
+                        }));
+                    const armorOptions = Object.keys(armor)
+                        .filter(a => player.inventory[a] > 0)
+                        .map(armorId => ({
+                            id: `sell_armor_${armorId}`,
+                            displayText: `[A] ${armor[armorId].name}`,
+                            description: `Sell for ${Math.max(1, Math.floor(armor[armorId].price / 10))} BTC`,
+                            trailText: `${player.inventory[armorId]}`,
+                            disabled: player.armor === armorId,
+                            className: player.armor === armorId ? "muted" : undefined,
+                        }));
+                    const itemOptions = Object.keys(items)
+                        .filter(itemId => player.inventory[itemId] > 0)
+                        .map(itemId => ({
+                            id: `sell_item_${itemId}`,
+                            displayText: `[I] ${items[itemId].name}`,
+                            description: `Sell for ${Math.max(1, Math.floor(items[itemId].price / 5))} BTC`,
+                            trailText: `${player.inventory[itemId]}`,
+                            disabled: false,
+                            className: undefined,
+                        }));
+                    const ringOptions = Object.keys(rings)
+                        .filter(ringId => player.inventory[ringId] > 0)
+                        .map(ringId => ({
+                            id: `sell_ring_${ringId}`,
+                            displayText: `[R] ${rings[ringId].name}`,
+                            description: `Sell for ${Math.max(1, Math.floor(rings[ringId].price / 5))} BTC`,
+                            trailText: `${player.inventory[ringId]}`,
+                            disabled: player.ring1 === ringId || player.ring2 === ringId,
+                            className: (player.ring1 === ringId || player.ring2 === ringId) ? "muted" : undefined,
+                        }));
+
+                    const options = [...weaponOptions, ...armorOptions, ...ringOptions, ...itemOptions];
+                    if (options.length === 0) {
+                        options.push({
+                            id: "_none",
+                            displayText: "Nothing to sell",
+                            description: "You have no weapons, armor, or items to sell.",
+                            disabled: true,
+                            className: "muted",
+                        });
+                    }
+                    options.push({
+                        id: "_back",
+                        displayText: "[Back]",
+                        description: "Return to the merchant menu",
+                    });
+                    return options;
+                },
+                select: (selectedOptionId) => {
+                    if (selectedOptionId === "_back" || selectedOptionId === "_none") {
+                        menu.close();
+                        return;
+                    }
+
+                    const [_, type, itemId] = selectedOptionId.split("_");
+                    let soldObject, value = 0;
+
+                    if (type === "weapon") {
+                        if (player.weapon === itemId) {
+                            merchant.say("You sure you wanna point that thing at me? I've got a 12 gauge hidden under my sleeve, you know...");
+                            return;
+                        }
+                        if (player.inventory[itemId] > 0) {
+                            soldObject = weapons[itemId];
+                            value = merchant.getSalePrice('weapon', weapons[itemId].price);
+                            player.giveBitcoins(value);
+                            player.inventory[itemId]--;
+                            if (player.inventory[itemId] <= 0) delete player.inventory[itemId];
+                        } else {
+                            console.error("Tried to sell an item that the player does not have", { itemId });
+                            return;
+                        }
+                    } else if (type === "armor") {
+                        if (player.armor === itemId) {
+                            merchant.say("What are you, a Lughead? You gotta strip down before you go selling that!");
+                            return;
+                        }
+                        if (player.inventory[itemId] > 0) {
+                            soldObject = armor[itemId];
+                            value = merchant.getSalePrice('armor', armor[itemId].price);
+                            player.giveBitcoins(value);
+                            player.inventory[itemId]--;
+                            if (player.inventory[itemId] <= 0) delete player.inventory[itemId];
+                        } else {
+                            console.error("Tried to sell armor that the player does not have", { itemId });
+                            return;
+                        }
+                    } else if (type === "ring") {
+                        if (player.hasEquippedRing(itemId)) {
+                            merchant.say("I don't swing that way, kid, but if you really wanna propose you gotta take the damn ring off.");
+                            return;
+                        }
+                        if (player.inventory[itemId] > 0) {
+                            soldObject = rings[itemId];
+                            value = merchant.getSalePrice('ring', rings[itemId].price);
+                            player.giveBitcoins(value);
+                            player.inventory[itemId]--;
+                            if (player.inventory[itemId] <= 0) delete player.inventory[itemId];
+                        } else {
+                            console.error("Tried to sell a ring that the player does not have", { itemId });
+                            return;
+                        }
+                    } else if (type === "item") {
+                        if (player.inventory[itemId] > 0) {
+                            soldObject = items[itemId];
+                            value = merchant.getSalePrice('item', items[itemId].price);
+                            player.giveBitcoins(value);
+                            player.inventory[itemId]--;
+                            if (player.inventory[itemId] <= 0) delete player.inventory[itemId];
+                        } else {
+                            console.error("Tried to sell an item that the player does not have", { itemId });
+                            return;
+                        }
+                    }
+
+                    playSFX('kaching');
+                    merchant.printTransactionMessage('sold', soldObject, value);
+                    menu.render();
+                    render();
+                },
+            },
+
+            gambler: {
+                title: "GAMBLER",
+                onOpen: () => {
+                    Portrait.show('gambler');
+                    gambler.say('Place yer bets!');
+                },
+                onClose: () => {
+                    gambler.isActiveOnFloor = false;
+                    const gamblerPosition = gambler.location();
+                    if (gamblerPosition) {
+                        MAP.setCell(gamblerPosition.x, gamblerPosition.y);
+                    }
+                    Portrait.hide();
+                },
+                landingHtml: () => {
+                    return (
+                        `<span class="gambler">&lt;GAMBLER&gt;</span> "Welcome, dungeon dweller! ` +
+                        `<span class="friendly">Roll a 12</span> and <span class="BTC">boost one of yer stats.</span> ` +
+                        `Just <span class="tooExpensive">${gambler.playPrice}</span> to play!"\n\n` +
+                        `You have <span class="BTC">${player.bitcoins} BTC</span> in your wallet`
+                    );
+                },
+                getOptions: () => {
+                    return [
+                        {
+                            id: "play",
+                            displayText: "Play the game",
+                            trailText: `${gambler.playPrice} BTC`,
+                            description: "Take your chance with the gambler",
+                        },
+                        {
+                            id: "_back",
+                            displayText: "Leave",
+                            description: "Leave this crusty fool",
+                        },
+                    ];
+                },
+                select: () => {
+                    gamble();
+                },
+            },
+            chest: {
+                title: "TREASURE CHEST",
+                onOpen: () => {
+                    Portrait.show('chest');
+                },
+                onClose: () => {
+                    Portrait.hide();
+                },
+                landingHtml: () => {
+                    return `\n\n\nYou found a treasure chest! Do you want to open it?`;
+                },
+                getOptions: () => {
+                    return [
+                        {
+                            id: "open",
+                            displayText: "Hell yeah! Fondle that booty!",
+                            description: "Claim your succulent reward!",
+                        },
+                        {
+                            id: "_back",
+                            displayText: "Resist your burning temptation...",
+                            description: "DON'T claim your succulent reward!",
+                        },
+                    ];
+                },
+                select: (selectedOptionId) => {
+                    if (selectedOptionId === "open") {
+                        openChest();
+                    }
+                    menu.close();
+                    render();
+                },
+            },
+            statAllocation: {
+                itemsPerPage: 12,
+                // Prevent menu from being closed with the Escape key
+                escapeDisabled: true,
+                title: () => isLevelUpAllocation ? "LEVEL UP" : "STAT ALLOCATION",
+                landingHtml: () => {
+                    return isLevelUpAllocation
+                        ? `You leveled up! Allocate <span class="action">${player.remainingPoints}</span> points to your stats.`
+                        : `Build your character using the <span class="action">${player.remainingPoints}</span> points you have been allotted. Use them wisely...`;
+                },
+                getOptions: () => {
                     // Helper to determine if a stat should be red
                     function isStatCapped(statKey) {
                         return isLevelUpAllocation && levelUpStatPointsAllocated[statKey] >= 2;
@@ -11411,105 +10810,104 @@ A Javascript game by <a href="https://milklounge.wang/tardquest/" target="_blank
                                 ? "Finish your level up and continue your adventure!"
                                 : "Begin YOUR TardQuest!",
                         },
-                        ];
-                    },
-                    select: (selectedOptionId) => {
-                        if (selectedOptionId === "confirm") {
-                            if (player.remainingPoints > 0) {
-                                updateBattleLog("You must allocate all points before continuing!");
+                    ];
+                },
+                select: (selectedOptionId) => {
+                    if (selectedOptionId === "confirm") {
+                        if (player.remainingPoints > 0) {
+                            updateBattleLog("You must allocate all points before continuing!");
+                            return;
+                        }
+                        if (isLevelUpAllocation) {
+                            isLevelUpAllocation = false;
+                            updateBattleLog("Stats increased! You consume an unsuspecting rat to restore your health. Poor feller...");
+                        } else {
+                            updateBattleLog("Stat allocation complete! You consume an unsuspecting rat to ensure you are in good health, and your adventure begins...");
+                        }
+                        menu.close();
+                        render();
+                        if (eatRatAnimationEnabled) animEatRat();
+                    } else if (selectedOptionId === "reset") {
+                        if (isLevelUpAllocation) {
+                            player.hp = player.maxHp = levelUpAllocatedStats.base.maxHp;
+                            player.defense = levelUpAllocatedStats.base.defense;
+                            player.strength = levelUpAllocatedStats.base.strength;
+                            player.persuasion = levelUpAllocatedStats.base.persuasion;
+                            player.endurance = levelUpAllocatedStats.base.endurance;
+                            player.speed = levelUpAllocatedStats.base.speed;
+                            player.luck = levelUpAllocatedStats.base.luck;
+                            player.remainingPoints = 6;
+                            // Reset the per-stat allocation tracker
+                            levelUpStatPointsAllocated = {
+                                maxHp: 0,
+                                defense: 0,
+                                strength: 0,
+                                persuasion: 0,
+                                endurance: 0,
+                                speed: 0,
+                                luck: 0
+                            };
+                            updateBattleLog("Level up stat allocation has been reset.");
+                        } else {
+                            resetStats();
+                        }
+                        menu.render();
+                        render();
+                    } else if (!isLevelUpAllocation && selectedOptionId === "rollDice") {
+                        rollDiceForStats();
+                        menu.render();
+                        render();
+                    } else if (player.remainingPoints > 0) {
+                        // Only restrict during level up, not initial allocation
+                        if (isLevelUpAllocation) {
+                            let statKey = null;
+                            switch (selectedOptionId) {
+                                case "hp": statKey = "maxHp"; break;
+                                case "defense": statKey = "defense"; break;
+                                case "strength": statKey = "strength"; break;
+                                case "persuasion": statKey = "persuasion"; break;
+                                case "endurance": statKey = "endurance"; break;
+                                case "speed": statKey = "speed"; break;
+                                case "luck": statKey = "luck"; break;
+                            }
+                            if (statKey && levelUpStatPointsAllocated[statKey] >= 2) {
+                                updateBattleLog(`<span class="action">You are only allowed 2 points per stat at a time!</span>`);
                                 return;
                             }
-                            if (isLevelUpAllocation) {
-                                isLevelUpAllocation = false;
-                                updateBattleLog("Stats increased! You consume an unsuspecting rat to restore your health. Poor feller...");
-                            } else {
-                                updateBattleLog("Stat allocation complete! You consume an unsuspecting rat to ensure you are in good health, and your adventure begins...");
-                            }
-                            menu.close();
-                            render();
-                            if (eatRatAnimationEnabled) animEatRat();
-                        } else if (selectedOptionId === "reset") {
-                            if (isLevelUpAllocation) {
-                                player.hp = player.maxHp = levelUpAllocatedStats.base.maxHp;
-                                player.defense = levelUpAllocatedStats.base.defense;
-                                player.strength = levelUpAllocatedStats.base.strength;
-                                player.persuasion = levelUpAllocatedStats.base.persuasion;
-                                player.endurance = levelUpAllocatedStats.base.endurance;
-                                player.speed = levelUpAllocatedStats.base.speed;
-                                player.luck = levelUpAllocatedStats.base.luck;
-                                player.remainingPoints = 6;
-                                // Reset the per-stat allocation tracker
-                                levelUpStatPointsAllocated = {
-                                    maxHp: 0,
-                                    defense: 0,
-                                    strength: 0,
-                                    persuasion: 0,
-                                    endurance: 0,
-                                    speed: 0,
-                                    luck: 0
-                                };
-                                updateBattleLog("Level up stat allocation has been reset.");
-                            } else {
-                                resetStats();
-                            }
-                            menu.render();
-                            render();
-                        } else if (!isLevelUpAllocation && selectedOptionId === "rollDice") {
-                            rollDiceForStats();
-                            menu.render();
-                            render();
-                        } else if (player.remainingPoints > 0) {
-                            // Only restrict during level up, not initial allocation
-                            if (isLevelUpAllocation) {
-                                let statKey = null;
-                                switch (selectedOptionId) {
-                                    case "hp": statKey = "maxHp"; break;
-                                    case "defense": statKey = "defense"; break;
-                                    case "strength": statKey = "strength"; break;
-                                    case "persuasion": statKey = "persuasion"; break;
-                                    case "endurance": statKey = "endurance"; break;
-                                    case "speed": statKey = "speed"; break;
-                                    case "luck": statKey = "luck"; break;
-                                }
-                                if (statKey && levelUpStatPointsAllocated[statKey] >= 2) {
-                                    updateBattleLog(`<span class="action">You are only allowed 2 points per stat at a time!</span>`);
-                                    return;
-                                }
-                                if (statKey) {
-                                    player[statKey] += 1;
-                                    levelUpStatPointsAllocated[statKey]++;
-                                    if (statKey === "maxHp") player.hp = player.maxHp;
-                                    player.remainingPoints--;
-                                    menu.render();
-                                    render();
-                                    return;
-                                }
-                            } else {
-                                switch (selectedOptionId) {
-                                    case "hp":
-                                        player.maxHp += 1;
-                                        player.hp = player.maxHp;
-                                        break;
-                                    case "defense":
-                                    case "strength":
-                                    case "persuasion":
-                                    case "endurance":
-                                    case "speed":
-                                    case "luck":
-                                        player[selectedOptionId]++;
-                                        break;
-                                }
+                            if (statKey) {
+                                player[statKey] += 1;
+                                levelUpStatPointsAllocated[statKey]++;
+                                if (statKey === "maxHp") player.hp = player.maxHp;
                                 player.remainingPoints--;
                                 menu.render();
                                 render();
+                                return;
                             }
                         } else {
-                            updateBattleLog("No points remaining to allocate!");
+                            switch (selectedOptionId) {
+                                case "hp":
+                                    player.maxHp += 1;
+                                    player.hp = player.maxHp;
+                                    break;
+                                case "defense":
+                                case "strength":
+                                case "persuasion":
+                                case "endurance":
+                                case "speed":
+                                case "luck":
+                                    player[selectedOptionId]++;
+                                    break;
+                            }
+                            player.remainingPoints--;
+                            menu.render();
+                            render();
                         }
-                    },
+                    } else {
+                        updateBattleLog("No points remaining to allocate!");
+                    }
                 },
-            },
-        };
+            }
+        });
 
         let isLevelUpAllocation = false;
         let levelUpAllocatedStats = {};

--- a/src/game.html
+++ b/src/game.html
@@ -460,6 +460,8 @@
         #menu .escapeMessage {
             position: absolute;
             bottom: 0;
+            width: 100%;
+            text-align: end;
         }
         /** End of Menu Styles **/
 
@@ -3890,13 +3892,13 @@ A Javascript game by <a href="https://milklounge.wang/tardquest/" target="_blank
                             ████░█
                             █████░
                             ██████
-                            ██░███
-                            ░░░███
-                            ░░░███
-                            ░░░███
-                            ░░░███
-                            ░░░███
-                            ░░██▀
+                            ██████
+                            ██████
+                            ████░█
+                            ██░░░█
+                            ░░░░░█
+                            ░░░░░█
+                            ░░░█▀
                             ░█▀
                             ▀
                         `,
@@ -7469,27 +7471,12 @@ A Javascript game by <a href="https://milklounge.wang/tardquest/" target="_blank
             },
 
             setPosition: function() {
-                let attempts = 0;
+                const points =
+                    shuffle(MAP.getMapDissolvePoints()).slice(0, 1)?.[0];
 
-                do {
-                    const x = Math.floor(Math.random() * WIDTH);
-                    const y = Math.floor(Math.random() * HEIGHT);
-
-                    const isEmptySpace =
-                        MAP.getCell(x, y)?.type === 'floor' &&
-                        (y !== player.y && x !== player.x);
-
-                    if (isEmptySpace) {
-                        MAP.setCell(x, y, "merchant");
-                        return;
-                    }
-                } while (attempts++ < 1000);
-
-                console.warn(
-                    `Unable to place the merchant after ${attempts} ` +
-                    `attempts. The merchant will be deactivated for this floor`
-                );
-                merchant.isActiveOnFloor = false;
+                if (points) {
+                    MAP.setCell(points.x, points.y, "merchant");
+                }
             },
 
             getSalePrice: function(itemType, price) {
@@ -7568,32 +7555,12 @@ A Javascript game by <a href="https://milklounge.wang/tardquest/" target="_blank
                 return MAP.locate("gambler");
             },
             set: function() {
-                let attempts = 0;
+                const points =
+                    shuffle(MAP.getMapDissolvePoints()).slice(0, 1)?.[0];
 
-                do {
-                    const x = Math.floor(Math.random() * WIDTH);
-                    const y = Math.floor(Math.random() * HEIGHT);
-
-                    const isMerchantSpace =
-                        merchant.isActiveOnFloor &&
-                        MAP.getCell(x, y)?.type === 'merchant';
-
-                    const isEmptySpace =
-                        MAP.getCell(x, y)?.type === 'floor' &&
-                        (y !== player.y && x !== player.x) &&
-                        !isMerchantSpace;
-
-                    if (isEmptySpace) {
-                        MAP.setCell(x, y, "gambler");
-                        return;
-                    }
-                } while (attempts++ < 1000);
-
-                console.warn(
-                    `Unable to place the gambler after ${attempts} attempts. ` +
-                    `The gambler will be deactivated for this floor`
-                );
-                gambler.isActiveOnFloor = false;
+                if (points) {
+                    MAP.setCell(points.x, points.y, "gambler");
+                }
             }
         };
 
@@ -8629,20 +8596,34 @@ A Javascript game by <a href="https://milklounge.wang/tardquest/" target="_blank
         let skipTitleScreen = false;
         let eatRatAnimationEnabled = true;
 
+        // Taken from https://en.wikipedia.org/wiki/Fisher%E2%80%93Yates_shuffle
+        function shuffle(array) {
+            if (!Array.isArray(array)) {
+                console.error(
+                    "Cannot shuffle something that isn't an array",
+                    { array }
+                );
+
+                return array;
+            }
+
+            for (let i = array.length - 1; i >= 1; i--) {
+                const j = Math.floor(Math.random() * (i + 1));
+                [array[i], array[j]] = [array[j], array[i]];
+            }
+            return array;
+        }
+
         function generateMap() {
             MAP.generate(WIDTH, HEIGHT, player.x, player.y);
 
-            /**
-             * @TODO: Finish reorganizing map generation functionality so that
-             *        these can be re-enabled
-             *
-            // 100% chance to spawn merchant on floor 1
             if (floor === 1) {
-                merchant.isActiveOnFloor = merchant.isAlive;
                 placeWelcomeBanner();
-            } else {
-                merchant.isActiveOnFloor = merchant.isAlive && Math.random() < 0.35;
             }
+
+            merchant.isActiveOnFloor =
+                merchant.isAlive &&
+                (floor === 1 || Math.random() < 0.35);
 
             if (floor === 40) {
                 placeNoboWall();
@@ -8656,31 +8637,15 @@ A Javascript game by <a href="https://milklounge.wang/tardquest/" target="_blank
             if (gambler.isActiveOnFloor) {
                 gambler.set();
             }
-            Object.keys(crackedFloorSteps).forEach(k => delete crackedFloorSteps[k]);
+
             spawnTreasureChests();
             spawnHealingTiles();
             spawnCrackedFloors();
 
-            // Generate minimap
-            const $minimap = document.getElementById('minimap');
-            $minimap.replaceChildren();
-
-            for (let y = 0; y < HEIGHT; y++) {
-                for (let x = 0; x < WIDTH; x++) {
-                    const $cell = document.createElement('span');
-                    $cell.id = MapCell.getCellId(x, y);
-                    $minimap.append($cell);
-                    // Track the minimap element in the MAP
-                    MAP[y][x].$element = $cell;
-                }
-
-                $minimap.append(document.createElement('br'));
-            }
-            */
-
             document.getElementById('minimapHeader').innerText =
                 `Dungeon Floor ${floor}`;
         }
+
         function loadSettings() {
             const music = localStorage.getItem("musicEnabled");
             if (music !== null) musicEnabled = music === "true";
@@ -8705,33 +8670,21 @@ A Javascript game by <a href="https://milklounge.wang/tardquest/" target="_blank
         loadSettings();
 
         function placeWelcomeBanner() {
-            if (MAP[player.y - 1][player.x]?.type === 'floor') {
+            if (MAP.getCell(player.x, player.y - 1)?.type === 'floor') {
                 // North of player
-                MAP[player.y - 1][player.x] = new MapCell(
-                    'tardspireBanner',
-                    { x: player.x, y: player.y - 1 },
-                );
+                MAP.setCell(player.x, player.y - 1, 'tardspireBanner');
                 player.dir = DIRECTIONS.indexOf('N');
-            } else if (MAP[player.y + 1][player.x]?.type === 'floor') {
+            } else if (MAP.getCell(player.x, player.y + 1)?.type === 'floor') {
                 // South of player
-                MAP[player.y + 1][player.x] = new MapCell(
-                    'tardspireBanner',
-                    { x: player.x, y: player.y + 1 }
-                );
+                MAP.setCell(player.x, player.y + 1, 'tardspireBanner');
                 player.dir = DIRECTIONS.indexOf('S');
-            } else if (MAP[player.y][player.x - 1]?.type === 'floor') {
+            } else if (MAP.getCell(player.x - 1, player.y)?.type === 'floor') {
                 // West of player
-                MAP[player.y][player.x - 1] = new MapCell(
-                    'tardspireBanner',
-                    { x: player.x - 1, y: player.y }
-                );
+                MAP.setCell(player.x - 1, player.y, 'tardspireBanner');
                 player.dir = DIRECTIONS.indexOf('W');
-            } else if (MAP[player.y][player.x + 1]?.type === 'floor') {
+            } else if (MAP.getCell(player.x + 1, player.y)?.type === 'floor') {
                 // East of player
-                MAP[player.y][player.x + 1] = new MapCell(
-                    'tardspireBanner',
-                    { x: player.x + 1, y: player.y }
-                );
+                MAP.setCell(player.x + 1, player.y, 'tardspireBanner');
                 player.dir = DIRECTIONS.indexOf('E');
             }
 
@@ -8739,92 +8692,47 @@ A Javascript game by <a href="https://milklounge.wang/tardquest/" target="_blank
             const gx = player.x - DX[player.dir];
             const gy = player.y - DY[player.dir];
 
-            if (MAP[gy][gx]?.type === 'wall') {
-                MAP[gy][gx] = new MapCell('gloryWall', { x: gx, y: gy });
+            if (MAP.getCell(gx, gy)?.type === 'wall') {
+                MAP.setCell(gx, gy, 'gloryWall');
             }
         }
 
         function placeNoboWall() {
-            const dissolvePoints = getMapDissolvePoints();
-            const index = Math.floor(Math.random() * dissolvePoints.length);
-            const dissolvePoint = dissolvePoints[index];
-            MAP[dissolvePoint.y][dissolvePoint.x] = new MapCell(
-                'noboWall',
-                { x: dissolvePoint.x, y: dissolvePoint.y }
-            );
+            const points = shuffle(MAP.getMapDissolvePoints()).slice(0, 1)?.[0];
+            if (points) {
+                MAP.setCell(points.x, points.y, "noboWall");
+            }
         }
 
         function spawnTreasureChests() {
-            const chestCount = Math.floor(Math.random() * 4) + 1; // 1 to 4 chests
-            let attempts = 0;
+            // 1 to 4 chests
+            const chestCount = Math.floor(Math.random() * 4) + 1;
 
-            for (let i = 0; i < chestCount; i++) {
-                while (attempts++ < 1000) {
-                    const x = Math.floor(Math.random() * WIDTH);
-                    const y = Math.floor(Math.random() * HEIGHT);
-
-                    const isEmptySpace =
-                        MAP[y][x]?.type === 'floor' &&
-                        (y !== player.y || x !== player.x);
-
-                    if (isEmptySpace) {
-                        const isMimic = Math.random() < 0.2; // 20% chance for mimic
-                        MAP[y][x] = new MapCell(
-                            isMimic ? 'mimic' : 'treasureChest',
-                            { x, y }
-                        );
-                        break;
-                    }
-                }
-            }
+            shuffle(MAP.getEmptyCellCoordinates())
+                .slice(0, chestCount)
+                .forEach((c) => {
+                    // 20% chance for mimic
+                    const isMimic = Math.random() < 0.2;
+                    MAP.setCell(c.x, c.y, isMimic ? 'mimic' : 'treasureChest');
+                });
         }
 
         function spawnHealingTiles() {
-            const healingTileCount = Math.floor(Math.random() * 6) + 1; // 1 to 6 healing tiles
-            let attempts = 0;
+            // 1 to 6 healing tiles
+            const healingTileCount = Math.floor(Math.random() * 6) + 1;
 
-            for (let i = 0; i < healingTileCount; i++) {
-                while (attempts++ < 1000) {
-                    const x = Math.floor(Math.random() * WIDTH);
-                    const y = Math.floor(Math.random() * HEIGHT);
-
-                    const isEmptySpace =
-                        MAP[y][x]?.type === 'floor' &&
-                        (y !== player.y || x !== player.x);
-
-                    if (isEmptySpace) {
-                        MAP[y][x] = new MapCell(
-                            'healingTile',
-                            { x, y }
-                        );
-                        break;
-                    }
-                }
-            }
+            shuffle(MAP.getEmptyCellCoordinates())
+                .slice(0, healingTileCount)
+                .forEach((c) => MAP.setCell(c.x, c.y, "healingTile"));
         }
 
         function spawnCrackedFloors() {
-            const crackedFloorCount = Math.floor(Math.random() * 4) + 1; // 1 to 4 cracked floors
-            let attempts = 0;
+            // 1 to 4 cracked floors
+            const crackedFloorCount = Math.floor(Math.random() * 4) + 1;
 
-            for (let i = 0; i < crackedFloorCount; i++) {
-                while (attempts++ < 1000) {
-                    const x = Math.floor(Math.random() * WIDTH);
-                    const y = Math.floor(Math.random() * HEIGHT);
-
-                    const isEmptySpace =
-                        MAP[y][x]?.type === 'floor' &&
-                        (y !== player.y || x !== player.x);
-
-                    if (isEmptySpace) {
-                        MAP[y][x] = new MapCell(
-                            'crackedFloorSlight',
-                            { x, y }
-                        );
-                        break;
-                    }
-                }
-            }
+            shuffle(MAP.getEmptyCellCoordinates())
+                .slice(0, crackedFloorCount)
+                .forEach((c) => MAP.setCell(c.x, c.y, "crackedFloorSlight"));
         }
 
         function getRandomMerchantItem() {

--- a/src/game.html
+++ b/src/game.html
@@ -336,7 +336,6 @@
             width: 110px;
             height: 256px;
             image-rendering: pixelated;
-            position: absolute;
             left: 0;
             bottom: 0;
             background-image: url(assets/fp-anim/fp-torch.gif);
@@ -407,14 +406,14 @@
 
         /** Menu Styles **/
         #menu:not(.hidden) {
+            background: #000;
             height: 315px;
             width: 360px;
-            flex-grow: 1;
             white-space: pre-wrap;
             display: flex;
             flex-direction: column;
             gap: 10px;
-            margin: 4px;
+            border: 4px solid #000;
             padding-bottom: 10px;
             z-index: 9;
         }
@@ -795,11 +794,6 @@
         #viewport > #menu,
         #viewport > #mouseControl {
             position: absolute;
-        }
-
-        #viewport > .ui-header {
-            position: relative;
-            z-index: 2;
         }
 
         #controls {

--- a/src/scripts/Map.js
+++ b/src/scripts/Map.js
@@ -1,0 +1,691 @@
+class MapCell {
+    static getCellId(x, y) {
+        return `map_cell_${x}_${y}`;
+    }
+
+    constructor(type = "floor", options = {}) {
+        const defaults = {
+            $element: null,
+            x: null,
+            y: null,
+            displayName: "Unknown",
+            mapCharacter: "?",
+            isSolid: false,
+            onEnter: null,
+            onTouch: null,
+            onExplode: null,
+            isExplored: true,
+            isVisible: null,
+        };
+
+        this.$element = options?.$element || defaults.$element;
+        this.x = typeof(options?.x === "number") ? options.x : defaults.x;
+        this.y = typeof(options?.y === "number") ? options.y : defaults.y;
+        this.type = type;
+        this.displayName = options?.displayName || defaults.displayName;
+        this.mapCharacter = options?.mapCharacter || defaults.mapCharacter;
+        this.isSolid = typeof options?.isSolid === "boolean"
+            ? options.isSolid
+            : defaults.isSolid;
+        this.onEnter = options?.onEnter || defaults.onEnter;
+        this.onTouch = options?.onTouch || defaults.onTouch;
+        this.onExplode = options?.onExplode || defaults.onExplode;
+        this.isExplored = typeof options?.isExplored === "boolean"
+            ? options.isExplored
+            : defaults.isExplored;
+        this.isVisible = options?.isVisible || defaults.isVisible;
+    }
+
+    refreshElement(overrides) {
+        if (!this.$element) {
+            console.warn("MapCell has no element to refresh");
+            return;
+        }
+
+        const cellProperties = {
+            ...{
+                displayName: this.displayName,
+                isExplored: this.isExplored,
+                isVisible: this.isVisible,
+                mapCharacter: this.mapCharacter,
+                type: this.type,
+            },
+            ...overrides,
+        }
+
+        let tile = '';
+        let tileClass = '';
+        if (!cellProperties.isExplored) {
+            tile = '?';
+            tileClass = 'unexplored';
+        } else {
+            // Use a visibility function if one is available
+            // Otherwise, assume that the tile is visible
+            const isVisible =
+                typeof cellProperties.isVisible !== 'function' ||
+                cellProperties.isVisible();
+
+            if (isVisible) {
+                tile = cellProperties.mapCharacter || '?';
+                tileClass = cellProperties.type || 'unknown';
+                tileClass = tileClass === 'mimic' ? 'treasureChest' : tileClass;
+            } else {
+                const emptyCell = this.generateCell();
+                tile = emptyCell.mapCharacter;
+                tileClass = emptyCell.type;
+            }
+        }
+
+        const displayName = cellProperties.isExplored
+            ? cellProperties.displayName
+            : "Unexplored";
+
+        this.$element.className = tileClass;
+
+        const hasCoordinates =
+            typeof this.x === "number" &&
+            typeof this.y === "number";
+
+        if (hasCoordinates) {
+            this.$element.setAttribute(
+                'data-tooltipHtml',
+                `<div class="mapCellDetails">
+                    <div class="enlargedTile ${tileClass}">${tile}</div>
+                    <div class="details">
+                        <div class="name">${displayName}</div>
+                        <div class="coordinates">(${this.x}, ${this.y})</div>
+                    </div>
+                </div>`
+            );
+
+            this.$element.setAttribute('data-tooltipPosition', 'right');
+        } else {
+            console.warn("No coordinates found for cell", {
+                cellProperties,
+                x: this.x,
+                y: this.y,
+            });
+            this.$element.removeAttribute('data-tooltipHtml');
+            this.$element.removeAttribute('data-tooltipPosition');
+        }
+
+        this.$element.innerText = tile;
+        Tooltip.refresh(this.$element);
+    }
+
+    static defaultsByType(type) {
+        /**
+         * A MapCell can have the following properties:
+         *
+         * displayName
+         *   The name that is displayed for the tile when hovering it on
+         *   the minimap
+         *
+         * mapCharacter
+         *   The character that represents the tile on the minimap
+         *
+         * isSolid
+         *   If true, acts like a wall and does not allow the player to
+         *   step onto it
+         *
+         * onEnter
+         *   A function that runs when the player steps onto the tile.
+         *   Always called with its own x, y coordinates. Won't work
+         *   when isSolid = true
+         *
+         * onTouch
+         *   A function that runs when the player touches the tile.
+         *   Won't work when isSolid = false
+         *
+         * onExplode
+         *   A function that runs when the player has blasted the tile
+         *   with a brick of C4. Always called with its own x, y
+         *   coordinates
+         *
+         * isExplored
+         *   When false, the cell appears as "Unexplored" on the minimap
+         *
+         * isVisible
+         *   A function that determines if the tile is visible. If it
+         *   returns false, the tile appears as a generic floor instead
+         */
+        const defaults = {
+            displayName: "Unknown",
+            mapCharacter: "?",
+            isSolid: false,
+            onEnter: null,
+            onTouch: null,
+            onExplode: null,
+            isExplored: true,
+            isVisible: null,
+        };
+
+        return { ...defaults, ...(types[type] || {}) };
+    }
+}
+
+
+/**
+ * The game's map
+ */
+class Map {
+    // The 2D array of map data, initialized by generate()
+    #cells = [];
+
+    // The types of cells that the map supports. Walls and floors are a minimum
+    // This is overwritten by setCellTypes()
+    #cellTypes = {
+        wall: {
+            displayName: "Wall",
+            mapCharacter: "#",
+            isSolid: true,
+        },
+        floor: {
+            displayName: "Floor",
+            mapCharacter: ".",
+        },
+    };
+
+    // Entities that exist within the map that are not fixed in place, such as
+    // the player or any wandering NPCs
+    #entities = {};
+
+    // The reference to the game's minimap element, set by setMinimap()
+    #$minimap = null;
+
+    // A list of object coordinates for cells that need to be rerendered
+    #rerenderList = [];
+
+    // Sets the reference to the game's minimap element
+    setMinimap($element) {
+        this.#$minimap = $element instanceof Element ? $element : null;
+    }
+
+    // Sets the types of cells available in the map
+    setCellTypes(cellTypes) {
+        this.#cellTypes = { ...this.#cellTypes, ...cellTypes };
+    }
+
+    // Returns a cell at a given coordinate
+    // Will return a wall if out of bounds/undefined to simulate blocking
+    getCell(x, y) {
+        return this.#cells[y]?.[x] || this.generateCell('wall');
+    }
+
+    // Sets a cell on the map at a given coordinate
+    // This can only overwrite cells in locations that already exist on the map
+    setCell(x, y, type = "floor", options = {}) {
+        if (!this.#cells?.[y]?.[x]) {
+            console.warn(
+                "Cell is outside of map boundaries and cannot be set",
+                { x, y, type, options }
+            );
+            return;
+        }
+
+        this.#cells[y][x] = this.generateCell(type, {
+            // Preserve the existing element for this space
+            $element: this.#cells[y][x].$element,
+            x,
+            y,
+            ...options
+        });
+
+        this.#rerenderList.push({x, y});
+    }
+
+    // Helper function to set up MapCell objects based on defined cell types
+    generateCell(type = "floor", options = {}) {
+        return new MapCell(
+            type,
+            { ...(this.#cellTypes[type] || {}), ...options }
+        );
+    }
+
+    // Finds and returns the coordinates of the first instance of a cell by type
+    // This does not return the positions of entities (eg: the player)
+    locate(cellType) {
+        for (let y = 0; y < this.#cells.length; y++) {
+            for (let x = 0; x < this.#cells[y].length; x++) {
+                if (this.#cells[y][x]?.type === cellType) {
+                    return { x, y };
+                }
+            }
+        }
+
+        return null;
+    }
+
+    // Sets details for entities, such as the player or any wandering NPCs
+    setEntities(entities) {
+        const changedCoordinates = this.getChangedCoordinates(
+            this.#entities,
+            entities
+        );
+
+        this.#rerenderList.push(...changedCoordinates);
+        this.#entities = entities;
+    }
+
+    // Given two sets of entities, returns a list of coordinates of spots that
+    // have changed on the map. Used to determine which entity cells to rerender
+    getChangedCoordinates(oldEntities, newEntities) {
+        const allKeys = new Set([
+            ...Object.keys(oldEntities),
+            ...Object.keys(newEntities)
+        ]);
+
+        const isDuplicate = (arr, coordinates) =>
+            arr.some(c => c.x === coordinates.x && c.y === coordinates.y);
+
+        return Array.from(allKeys).reduce((acc, key) => {
+            const oldCoordinates = oldEntities[key];
+            const newCoordinates = newEntities[key];
+
+            if (newCoordinates.forceRefresh) {
+                if (!isDuplicate(acc, newCoordinates)) {
+                    acc.push(newCoordinates);
+                }
+            }
+
+            if (!oldCoordinates && newCoordinates) {
+                if (!isDuplicate(acc, newCoordinates)) {
+                    acc.push(newCoordinates);
+                }
+            } else if (oldCoordinates && !newCoordinates) {
+                if (!isDuplicate(acc, oldCoordinates)) {
+                    acc.push(oldCoordinates);
+                }
+            } else if (oldCoordinates.x !== newCoordinates.x || oldCoordinates.y !== newCoordinates.y) {
+                if (!isDuplicate(acc, oldCoordinates)) {
+                    acc.push(oldCoordinates);
+                }
+
+                if (!isDuplicate(acc, newCoordinates)) {
+                    acc.push(newCoordinates);
+                }
+            }
+
+            return acc;
+        }, []);
+    }
+
+    // Generates the map
+    // sizeX and sizeY determine the width and height of the map
+    // playerStartX and playerStartY point to where the player resides, so this
+    // spot should not be filled in
+    generate(sizeX, sizeY, playerStartX, playerStartY) {
+        const exitPosition = this.getExitPosition(
+            sizeX,
+            sizeY,
+            playerStartX,
+            playerStartY
+        );
+
+        // Fill in walls
+        for (let y = 0; y < sizeY; y++) {
+            this.#cells[y] = [];
+            for (let x = 0; x < sizeX; x++) {
+                this.#cells[y][x] = this.generateCell(
+                    'wall',
+                    { x, y, isExplored: false }
+                );
+            }
+        }
+
+        // Carve out a path
+        let position = { x: playerStartX, y: playerStartY };
+        let stack = null;
+
+        do {
+            stack = this.carvePath(sizeX, sizeY, exitPosition, [position]);
+        } while (stack === null);
+
+        for (let i in stack) {
+            this.#cells[stack[i].y][stack[i].x] = this.generateCell(
+                'floor',
+                { x: stack[i].x, y: stack[i].y, isExplored: false }
+            );
+        }
+
+        const dissolveIterations = 10;
+        for (let i = 0; i < dissolveIterations; i++) {
+            this.dissolveMap();
+        }
+
+        this.#cells[playerStartY][playerStartX] = this.generateCell('floor', {
+            x: playerStartX,
+            y: playerStartY,
+        });
+
+        this.#cells[exitPosition.y][exitPosition.x] = this.generateCell(
+            'exit',
+            {
+                x: exitPosition.x,
+                y: exitPosition.y,
+                isExplored: false,
+            }
+        );
+
+        // BADNESS BELOW!!!
+
+        /*
+        // 100% chance to spawn merchant on floor 1
+        if (floor === 1) {
+            merchant.isActiveOnFloor = merchant.isAlive;
+            placeWelcomeBanner();
+        } else {
+            merchant.isActiveOnFloor = merchant.isAlive && Math.random() < 0.35;
+        }
+
+        if (floor === 40) {
+            placeNoboWall();
+        }
+
+        if (merchant.isActiveOnFloor) {
+            merchant.set();
+        }
+
+        gambler.isActiveOnFloor = gambler.isAlive && Math.random() < 0.35;
+        if (gambler.isActiveOnFloor) {
+            gambler.set();
+        }
+        Object.keys(crackedFloorSteps).forEach(k => delete crackedFloorSteps[k]);
+        */
+        /*
+        this.spawnTreasureChests(playerStartX, playerStartY);
+        this.spawnHealingTiles(playerStartX, playerStartY);
+        this.spawnCrackedFloors(playerStartX, playerStartY);
+        */
+
+        // BADNESS ABOVE!!! (PRESUMABLY!!!)
+
+        this.initializeMinimap();
+    }
+
+    // Generates and returns a set of coordinates for where the exit should be
+    getExitPosition(sizeX, sizeY, playerStartX, playerStartY) {
+        const margin = 2;
+        const exit = {
+            x: sizeX - margin,
+            y: sizeY - margin,
+        };
+        const possiblePositions = [['x', 'y'], ['x'], ['y']];
+        const positions = possiblePositions[
+            Math.floor(Math.random() * possiblePositions.length)
+        ];
+
+        for (let p in positions) {
+            if (positions[p] === 'x') {
+                const exitOffsetX = Math.round(Math.random() * Math.round(sizeX / 10));
+                exit.x = playerStartX < sizeX / margin
+                    ? sizeX - margin - exitOffsetX
+                    : margin + exitOffsetX;
+            } else {
+                const exitOffsetY = Math.round(Math.random() * Math.round(sizeY / 10));
+                exit.y = playerStartY < sizeY / margin
+                    ? sizeY - margin - exitOffsetY
+                    : margin + exitOffsetY;
+            }
+        }
+
+        return exit;
+    }
+
+    // This is fucking bugged, bro
+    carvePath(mapSizeX, mapSizeY, exitPosition, stack) {
+        const direction = Math.random() < 0.5 ? 'horizontal' : 'vertical';
+        const step = Math.random() < 0.5 ? -1 : 1;
+        let lastPosition = stack[stack.length - 1];
+
+        for (let i=0; i<2; i++) {
+            const nextPosition = {
+                x: lastPosition.x + (direction === 'horizontal' ? step : 0),
+                y: lastPosition.y + (direction === 'vertical' ? step : 0),
+            };
+
+            const atMapEdge =
+                nextPosition.x === 0 ||
+                nextPosition.y === 0 ||
+                nextPosition.x === mapSizeX - 1 ||
+                nextPosition.y === mapSizeY - 1;
+
+            if (atMapEdge) {
+                return null;
+            }
+
+            const alreadyVisited = stack.find((seenPosition) =>
+                seenPosition.x === nextPosition.x &&
+                seenPosition.y === nextPosition.y
+            );
+            if (alreadyVisited) {
+                return null;
+            }
+
+            stack.push(nextPosition);
+
+            const reachedEnd =
+                nextPosition.x === exitPosition.x &&
+                nextPosition.y === exitPosition.y;
+
+            if (reachedEnd) {
+                return stack;
+            }
+
+            lastPosition = nextPosition;
+        }
+
+        let result;
+        for (let i=0; i<100; i++) {
+            result = this.carvePath(mapSizeX, mapSizeY, exitPosition, stack);
+            if (result) {
+                break;
+            }
+        }
+
+        return result;
+    }
+
+    // Carves hallways and dead ends into the map
+    dissolveMap() {
+        let dissolvePoints = this.getMapDissolvePoints();
+        const totalPointsToDissolve = Math.floor(dissolvePoints.length / 2);
+        if (totalPointsToDissolve < 1) {
+            return;
+        }
+
+        for (let i = 0; i < totalPointsToDissolve; i++) {
+            const index = Math.floor(Math.random() * dissolvePoints.length);
+            const dissolvePoint = dissolvePoints[index];
+            this.#cells[dissolvePoint.y][dissolvePoint.x] = this.generateCell(
+                'floor',
+                {
+                    x: dissolvePoint.x,
+                    y: dissolvePoint.y,
+                    isExplored:
+                        this.#cells[dissolvePoint.y][dissolvePoint.x].isExplored,
+                }
+            );
+            dissolvePoints = dissolvePoints.splice(index, 1);
+        }
+    }
+
+    // Returns a list of coordinates where the map could be dissolved
+    // A dissolve point is any spot on the map that's not at the map's edge, but
+    // is a wall that has three surrounding walls
+    // @TODO Make sure this works for other types of walls, eg iceWall
+    //       Maybe check for isSolid instead of type === 'wall'
+    getMapDissolvePoints() {
+        const margin = 2;
+        const dissolvePoints = [];
+
+        for (let y = margin; y < this.#cells.length - margin; y++) {
+            for (let x = margin; x < this.#cells[0].length - margin; x++) {
+                const isDissolvePoint = this.#cells[y][x]?.type === 'wall' && (
+                    (this.#cells[y - 1][x]?.type === 'wall' ? 1 : 0) +
+                    (this.#cells[y + 1][x]?.type === 'wall' ? 1 : 0) +
+                    (this.#cells[y][x - 1]?.type === 'wall' ? 1 : 0) +
+                    (this.#cells[y][x + 1]?.type === 'wall' ? 1 : 0)
+                ) === 3;
+
+                if (isDissolvePoint) {
+                    dissolvePoints.push({x, y});
+                }
+            }
+        }
+
+        return dissolvePoints;
+    }
+
+    // Spawns treasure chests and mimics on the map (hey, mimics are chests too)
+    spawnTreasureChests(playerStartX, playerStartY) {
+        const chestCount = Math.floor(Math.random() * 4) + 1; // 1 to 4 chests
+        let attempts = 0;
+
+        for (let i = 0; i < chestCount; i++) {
+            while (attempts++ < 1000) {
+                const x = Math.floor(Math.random() * this.#cells[0].length);
+                const y = Math.floor(Math.random() * this.#cells.length);
+
+                const isEmptySpace =
+                    this.#cells[y][x]?.type === 'floor' &&
+                    (y !== playerStartY || x !== playerStartX);
+
+                if (isEmptySpace) {
+                    const isMimic = Math.random() < 0.2; // 20% chance for mimic
+                    this.#cells[y][x] = this.generateCell(
+                        isMimic ? 'mimic' : 'treasureChest',
+                        { x, y }
+                    );
+                    break;
+                }
+            }
+        }
+    }
+
+    // Spawns healing tiles on the map
+    spawnHealingTiles(playerStartX, playerStartY) {
+        const healingTileCount = Math.floor(Math.random() * 6) + 1; // 1 to 6 healing tiles
+        let attempts = 0;
+
+        for (let i = 0; i < healingTileCount; i++) {
+            while (attempts++ < 1000) {
+                const x = Math.floor(Math.random() * this.#cells[0].length);
+                const y = Math.floor(Math.random() * this.#cells.length);
+
+                const isEmptySpace =
+                    this.#cells[y][x]?.type === 'floor' &&
+                    (y !== playerStartY || x !== playerStartX);
+
+                if (isEmptySpace) {
+                    this.#cells[y][x] =
+                        this.generateCell('healingTile', { x, y });
+                    break;
+                }
+            }
+        }
+    }
+
+    // Spawns cracked floors on the map
+    spawnCrackedFloors(playerStartX, playerStartY) {
+        const crackedFloorCount = Math.floor(Math.random() * 4) + 1; // 1 to 4 cracked floors
+        let attempts = 0;
+
+        for (let i = 0; i < crackedFloorCount; i++) {
+            while (attempts++ < 1000) {
+                const x = Math.floor(Math.random() * this.#cells[0].length);
+                const y = Math.floor(Math.random() * this.#cells.length);
+
+                const isEmptySpace =
+                    this.getCell(x, y)?.type === 'floor' &&
+                    (y !== playerStartY || x !== playerStartX);
+
+                if (isEmptySpace) {
+                    this.setCell(x, y, "crackedFloorSlight", { x, y });
+                    break;
+                }
+            }
+        }
+    }
+
+    // Sets up the minimap element if the element has been defined
+    initializeMinimap() {
+        if (!this.#$minimap) {
+            console.debug(
+                "Cannot generate minimap because no minimap element has " +
+                "been defined"
+            );
+            return;
+        }
+
+        this.#$minimap.replaceChildren();
+
+        for (let y = 0; y < this.#cells.length; y++) {
+            for (let x = 0; x < this.#cells[y].length; x++) {
+                const $cell = document.createElement('span');
+                $cell.id = MapCell.getCellId(x, y);
+                this.#$minimap.append($cell);
+
+                // Track the minimap element in the corresponding map cell
+                this.#cells[y][x].$element = $cell;
+
+                // Make sure we render the cell
+                this.#rerenderList.push({x, y});
+            }
+
+            this.#$minimap.append(document.createElement('br'));
+        }
+    }
+
+    // Updates the cells on the minimap based on coordinates in the rerenderList
+    refreshMinimap() {
+        if (!this.#$minimap) {
+            console.warn("No minimap defined. Cannot rerender");
+            return;
+        }
+
+        this.#rerenderList.forEach((cellCoords) => {
+            const cell = this.#cells[cellCoords.y]?.[cellCoords.x];
+
+            if (!cell) {
+                console.error("Could not find cell to rerender", {
+                    cellCoords,
+                    cells: this.#cells,
+                });
+                return;
+            }
+
+            const overrides = Object.entries(this.#entities).find(
+                ([id, entity]) =>
+                    entity.x === cellCoords.x &&
+                    entity.y === cellCoords.y
+            )?.[1] || {};
+
+            cell.refreshElement(overrides);
+        });
+
+        this.#rerenderList = [];
+    }
+
+    // Reveals a spot on the map, regardless of walls
+    revealSpot(spotX, spotY, radius) {
+        for (let y=spotY-radius; y<=spotY+radius; y++) {
+            for (let x=spotX-radius; x<=spotX+radius; x++) {
+                if (typeof this.#cells[y]?.[x] !== "undefined") {
+                    this.#cells[y][x].isExplored = true;
+                    this.#rerenderList.push({x, y});
+                }
+            }
+        }
+    }
+
+    // Reveals the entire map
+    reveal() {
+        for (let y=0; y<this.#cells.length; y++) {
+            for (let x=0; x<this.#cells[y].length; x++) {
+                this.#cells[y][x].isExplored = true;
+                this.#rerenderList.push({x, y});
+            }
+        }
+    }
+}

--- a/src/scripts/Map.js
+++ b/src/scripts/Map.js
@@ -55,9 +55,11 @@ class MapCell {
 
         let tile = '';
         let tileClass = '';
+        let displayName = '';
         if (!cellProperties.isExplored) {
             tile = '?';
             tileClass = 'unexplored';
+            displayName = "Unexplored";
         } else {
             // Use a visibility function if one is available
             // Otherwise, assume that the tile is visible
@@ -69,16 +71,13 @@ class MapCell {
                 tile = cellProperties.mapCharacter || '?';
                 tileClass = cellProperties.type || 'unknown';
                 tileClass = tileClass === 'mimic' ? 'treasureChest' : tileClass;
+                displayName = cellProperties.displayName;
             } else {
-                const emptyCell = this.generateCell();
-                tile = emptyCell.mapCharacter;
-                tileClass = emptyCell.type;
+                tile = ".";
+                tileClass = "floor";
+                displayName = "Floor";
             }
         }
-
-        const displayName = cellProperties.isExplored
-            ? cellProperties.displayName
-            : "Unexplored";
 
         this.$element.className = tileClass;
 
@@ -226,6 +225,9 @@ class Map {
         this.#cells[y][x] = this.generateCell(type, {
             // Preserve the existing element for this space
             $element: this.#cells[y][x].$element,
+            isExplored: typeof this.#cells[y][x].isExplored === "boolean"
+                ? this.#cells[y][x].isExplored
+                : true,
             x,
             y,
             ...options
@@ -254,6 +256,26 @@ class Map {
         }
 
         return null;
+    }
+
+    cellIsOccupied(x, y) {
+        return Boolean(Object.entries(this.#entities).find(
+            ([id, entity]) => entity.x === x && entity.y === y
+        ) || this.getCell(x, y)?.type !== "floor");
+    }
+
+    getEmptyCellCoordinates() {
+        const coordinates = [];
+
+        for (let y=0; y<this.#cells.length; y++) {
+            for (let x=0; x<this.#cells[y].length; x++) {
+                if (!this.cellIsOccupied(x, y)) {
+                    coordinates.push({ x, y });
+                }
+            }
+        }
+
+        return coordinates;
     }
 
     // Sets details for entities, such as the player or any wandering NPCs
@@ -366,39 +388,6 @@ class Map {
                 isExplored: false,
             }
         );
-
-        // BADNESS BELOW!!!
-
-        /*
-        // 100% chance to spawn merchant on floor 1
-        if (floor === 1) {
-            merchant.isActiveOnFloor = merchant.isAlive;
-            placeWelcomeBanner();
-        } else {
-            merchant.isActiveOnFloor = merchant.isAlive && Math.random() < 0.35;
-        }
-
-        if (floor === 40) {
-            placeNoboWall();
-        }
-
-        if (merchant.isActiveOnFloor) {
-            merchant.set();
-        }
-
-        gambler.isActiveOnFloor = gambler.isAlive && Math.random() < 0.35;
-        if (gambler.isActiveOnFloor) {
-            gambler.set();
-        }
-        Object.keys(crackedFloorSteps).forEach(k => delete crackedFloorSteps[k]);
-        */
-        /*
-        this.spawnTreasureChests(playerStartX, playerStartY);
-        this.spawnHealingTiles(playerStartX, playerStartY);
-        this.spawnCrackedFloors(playerStartX, playerStartY);
-        */
-
-        // BADNESS ABOVE!!! (PRESUMABLY!!!)
 
         this.initializeMinimap();
     }

--- a/src/scripts/Map.js
+++ b/src/scripts/Map.js
@@ -421,7 +421,6 @@ class Map {
         return exit;
     }
 
-    // This is fucking bugged, bro
     carvePath(mapSizeX, mapSizeY, exitPosition, stack) {
         const direction = Math.random() < 0.5 ? 'horizontal' : 'vertical';
         const step = Math.random() < 0.5 ? -1 : 1;
@@ -524,77 +523,6 @@ class Map {
         }
 
         return dissolvePoints;
-    }
-
-    // Spawns treasure chests and mimics on the map (hey, mimics are chests too)
-    spawnTreasureChests(playerStartX, playerStartY) {
-        const chestCount = Math.floor(Math.random() * 4) + 1; // 1 to 4 chests
-        let attempts = 0;
-
-        for (let i = 0; i < chestCount; i++) {
-            while (attempts++ < 1000) {
-                const x = Math.floor(Math.random() * this.#cells[0].length);
-                const y = Math.floor(Math.random() * this.#cells.length);
-
-                const isEmptySpace =
-                    this.#cells[y][x]?.type === 'floor' &&
-                    (y !== playerStartY || x !== playerStartX);
-
-                if (isEmptySpace) {
-                    const isMimic = Math.random() < 0.2; // 20% chance for mimic
-                    this.#cells[y][x] = this.generateCell(
-                        isMimic ? 'mimic' : 'treasureChest',
-                        { x, y }
-                    );
-                    break;
-                }
-            }
-        }
-    }
-
-    // Spawns healing tiles on the map
-    spawnHealingTiles(playerStartX, playerStartY) {
-        const healingTileCount = Math.floor(Math.random() * 6) + 1; // 1 to 6 healing tiles
-        let attempts = 0;
-
-        for (let i = 0; i < healingTileCount; i++) {
-            while (attempts++ < 1000) {
-                const x = Math.floor(Math.random() * this.#cells[0].length);
-                const y = Math.floor(Math.random() * this.#cells.length);
-
-                const isEmptySpace =
-                    this.#cells[y][x]?.type === 'floor' &&
-                    (y !== playerStartY || x !== playerStartX);
-
-                if (isEmptySpace) {
-                    this.#cells[y][x] =
-                        this.generateCell('healingTile', { x, y });
-                    break;
-                }
-            }
-        }
-    }
-
-    // Spawns cracked floors on the map
-    spawnCrackedFloors(playerStartX, playerStartY) {
-        const crackedFloorCount = Math.floor(Math.random() * 4) + 1; // 1 to 4 cracked floors
-        let attempts = 0;
-
-        for (let i = 0; i < crackedFloorCount; i++) {
-            while (attempts++ < 1000) {
-                const x = Math.floor(Math.random() * this.#cells[0].length);
-                const y = Math.floor(Math.random() * this.#cells.length);
-
-                const isEmptySpace =
-                    this.getCell(x, y)?.type === 'floor' &&
-                    (y !== playerStartY || x !== playerStartX);
-
-                if (isEmptySpace) {
-                    this.setCell(x, y, "crackedFloorSlight", { x, y });
-                    break;
-                }
-            }
-        }
     }
 
     // Sets up the minimap element if the element has been defined

--- a/src/scripts/Menu.js
+++ b/src/scripts/Menu.js
@@ -13,9 +13,11 @@ class Menu {
     #currentPage = 0; // Track the current page for paginated menus
     #defaultItemsPerPage = 10;
 
+    #onOpen = null;
     #onHighlight = null;
     #onSelect = null;
     #onCancel = null;
+    #onClose = null;
 
     constructor($menu, menus) {
         if ($menu) {
@@ -59,6 +61,15 @@ class Menu {
         this.#defaultItemsPerPage = itemsPerPage;
     }
 
+    setOnOpen(onOpen) {
+        if (typeof onOpen !== "function") {
+            console.error("onOpen must be a function", { onOpen });
+            return;
+        }
+
+        this.#onOpen = onOpen;
+    }
+
     setOnHighlight(onHighlight) {
         if (typeof onHighlight !== "function") {
             console.error("onHighlight must be a function", { onHighlight });
@@ -84,6 +95,15 @@ class Menu {
         }
 
         this.#onCancel = onCancel;
+    }
+
+    setOnClose(onClose) {
+        if (typeof onClose !== "function") {
+            console.error("onClose must be a function", { onClose });
+            return;
+        }
+
+        this.#onClose = onClose;
     }
 
     initializeMenu($menu) {
@@ -127,6 +147,10 @@ class Menu {
 
         const activeMenu = this.#menus[menuName];
 
+        if (this.#breadcrumbs.length === 0) {
+            this.#onOpen?.();
+        }
+
         this.#breadcrumbs.push({
             menuName,
             selectionIndex: this.#selectionIndex,
@@ -155,6 +179,8 @@ class Menu {
         if (this.#breadcrumbs.length === 0) {
             this.#elements.$menu.classList.add('hidden');
             document.getElementById('game').classList.remove('hidden');
+
+            this.#onClose?.();
         }
 
         this.#onCancel?.();
@@ -168,6 +194,7 @@ class Menu {
         this.#elements.$menu.classList.add('hidden');
         document.getElementById('game').classList.remove('hidden');
 
+        this.#onClose?.();
         this.#onCancel?.();
     }
 

--- a/src/scripts/Menu.js
+++ b/src/scripts/Menu.js
@@ -181,9 +181,9 @@ class Menu {
             document.getElementById('game').classList.remove('hidden');
 
             this.#onClose?.();
+        } else {
+            this.#onCancel?.();
         }
-
-        this.#onCancel?.();
     }
 
     closeAll() {
@@ -195,7 +195,6 @@ class Menu {
         document.getElementById('game').classList.remove('hidden');
 
         this.#onClose?.();
-        this.#onCancel?.();
     }
 
     highlightOption(index) {

--- a/src/scripts/Menu.js
+++ b/src/scripts/Menu.js
@@ -313,9 +313,6 @@ class Menu {
     }
 
     handleInput(key) {
-        // @TODO Handle elsewhere
-        // if (animationActive) return;
-
         const activeMenu = this.getActiveMenu();
         const options = activeMenu.getOptions();
         const itemsPerPage = this.getItemsPerPage();

--- a/src/scripts/Menu.js
+++ b/src/scripts/Menu.js
@@ -1,0 +1,378 @@
+class Menu {
+    #elements = {
+        $menu: null,
+        $landing: null,
+        $list: null,
+        $selectionDescription: null,
+        $escapeMessage: null,
+    };
+
+    #menus = {};
+    #breadcrumbs = [];
+    #selectionIndex = 0;
+    #currentPage = 0; // Track the current page for paginated menus
+    #defaultItemsPerPage = 10;
+
+    #onHighlight = null;
+    #onSelect = null;
+    #onCancel = null;
+
+    constructor($menu, menus) {
+        if ($menu) {
+            this.setMenuElement($menu);
+        }
+
+        if (menus) {
+            this.setMenus(menus);
+        }
+    }
+
+    setMenuElement($menu) {
+        if (! $menu instanceof Element) {
+            console.error("$menu must be an element", { $menu });
+            return;
+        }
+
+        this.initializeMenu($menu);
+    }
+
+    setMenus(menus) {
+        if (typeof menus !== "object") {
+            console.error("menus must be an object", { menus });
+            return;
+        }
+
+        this.#menus = menus;
+    }
+
+    setDefaultItemsPerPage(defaultItemsPerPage) {
+        const itemsPerPage = parseInt(defaultItemsPerPage, 10);
+
+        if (itemsPerPage < 1) {
+            console.error(
+                "defaultItemsPerPage must be a positive value",
+                { defaultItemsPerPage }
+            );
+            return;
+        }
+
+        this.#defaultItemsPerPage = itemsPerPage;
+    }
+
+    setOnHighlight(onHighlight) {
+        if (typeof onHighlight !== "function") {
+            console.error("onHighlight must be a function", { onHighlight });
+            return;
+        }
+
+        this.#onHighlight = onHighlight;
+    }
+
+    setOnSelect(onSelect) {
+        if (typeof onSelect !== "function") {
+            console.error("onSelect must be a function", { onSelect });
+            return;
+        }
+
+        this.#onSelect = onSelect;
+    }
+
+    setOnCancel(onCancel) {
+        if (typeof onCancel !== "function") {
+            console.error("onCancel must be a function", { onCancel });
+            return;
+        }
+
+        this.#onCancel = onCancel;
+    }
+
+    initializeMenu($menu) {
+        this.#elements.$menu = $menu;
+        this.#elements.$landing = document.createElement('div');
+        this.#elements.$landing.classList.add("landing");
+
+        this.#elements.$list = document.createElement('div');
+        this.#elements.$list.classList.add("list");
+
+        this.#elements.$selectionDescription = document.createElement('div');
+        this.#elements.$selectionDescription.classList.add("selectionDescription");
+
+        this.#elements.$escapeMessage = document.createElement('div');
+        this.#elements.$escapeMessage.classList.add("escapeMessage");
+        this.#elements.$escapeMessage.innerText = "Press Escape to go back";
+
+        this.#elements.$menu.classList.add("hidden");
+
+        this.#elements.$menu.replaceChildren(
+            this.#elements.$landing,
+            this.#elements.$list,
+            this.#elements.$selectionDescription,
+            this.#elements.$escapeMessage,
+        );
+    }
+
+    getActiveMenu() {
+        return this.#menus[this.#breadcrumbs.at(-1)?.menuName] || undefined;
+    }
+
+    isOpen() {
+        return this.#breadcrumbs.length > 0;
+    }
+
+    open(menuName) {
+        if (typeof this.#menus[menuName] === 'undefined') {
+            console.error('The requested menu does not exist', { menuName });
+            return;
+        }
+
+        const activeMenu = this.#menus[menuName];
+
+        this.#breadcrumbs.push({
+            menuName,
+            selectionIndex: this.#selectionIndex,
+            currentPage: this.#currentPage,
+        });
+
+        this.#selectionIndex = 0; // Reset selection index
+        this.#currentPage = 0; // Reset to the first page
+
+        document.getElementById('game').classList.add('hidden');
+        this.#elements.$menu.classList.remove('hidden');
+        this.#elements.$selectionDescription.textContent = '';
+
+        activeMenu.onOpen?.();
+        this.render();
+    }
+
+    close() {
+        const previousMenu = this.#breadcrumbs.pop();
+        if (previousMenu) {
+            this.#menus[previousMenu.menuName].onClose?.();
+            this.#selectionIndex = previousMenu.selectionIndex;
+            this.#currentPage = previousMenu.currentPage;
+        }
+
+        if (this.#breadcrumbs.length === 0) {
+            this.#elements.$menu.classList.add('hidden');
+            document.getElementById('game').classList.remove('hidden');
+        }
+
+        this.#onCancel?.();
+    }
+
+    closeAll() {
+        while (this.#breadcrumbs.length > 0) {
+            const previousMenu = this.#breadcrumbs.pop();
+            this.#menus[previousMenu.menuName].onClose?.();
+        }
+        this.#elements.$menu.classList.add('hidden');
+        document.getElementById('game').classList.remove('hidden');
+
+        this.#onCancel?.();
+    }
+
+    highlightOption(index) {
+        this.#selectionIndex = index;
+    }
+
+    getItemsPerPage() {
+        const itemsPerPageOverride =
+            parseInt(this.getActiveMenu()?.itemsPerPage || 0, 10);
+
+        return itemsPerPageOverride > 0
+            ? itemsPerPageOverride
+            : this.#defaultItemsPerPage;
+    }
+
+    render() {
+        const activeMenu = this.getActiveMenu();
+        if (typeof activeMenu === 'undefined') {
+            return;
+        }
+
+        const options = activeMenu.getOptions();
+
+        const itemsPerPage = this.getItemsPerPage();
+        const totalPages = Math.ceil(options.length / itemsPerPage); // Calculate total pages
+        const startIndex = this.#currentPage * itemsPerPage;
+        const endIndex = startIndex + itemsPerPage;
+        const paginatedOptions = options.slice(startIndex, endIndex);
+
+        // Render the title and page indicator
+        const titleText = typeof activeMenu.title === 'function' ? activeMenu.title() : activeMenu.title;
+        const titleHtml = activeMenu.title ? `<span class="title">「${titleText}」</span>` : '';
+
+        const landingHtml = `<div>${activeMenu?.landingHtml?.() || ''}</div>`;
+        this.#elements.$landing.innerHTML = titleHtml + landingHtml;
+
+        const paginationText = totalPages > 1 ? (
+            (this.#currentPage > 0 ? '◀ ' : '  ') +
+            `Page ${this.#currentPage + 1} of ${totalPages}` +
+            (this.#currentPage + 1 < totalPages ? ' ▶' : '  ')
+        ) : '';
+
+        const $list = document.createElement('div');
+        $list.className = "list";
+
+        const $pageNumber = document.createElement("div");
+        $pageNumber.className = "pageNumber";
+        $pageNumber.innerText = paginationText;
+        $list.appendChild($pageNumber);
+
+        // Render the options for the current page
+        paginatedOptions.forEach((option, index) => {
+            const isSelectedLine = index === this.#selectionIndex;
+            const classes = [
+                "option",
+                ...(option.className ? [option.className] : []),
+                ...(isSelectedLine ? ["selected"] : []),
+            ];
+
+            const $option = document.createElement("span");
+            $option.classList.add(...classes);
+            $option.dataset.index = index;
+
+            $option.onmouseover = () => this.setSelection(index);
+            $option.onclick = () => this.select(index);
+
+            const trailText = option.trailText ? `${option.trailText}` : '';
+
+            const maxLineLength = 56; // Max "." trail width
+            const dots = trailText
+                ? '.'.repeat(Math.max(0, maxLineLength - option.displayText.length - trailText.length - 4))
+                : '';
+
+            $option.appendChild(document.createTextNode(
+                `${option.displayText}${dots}${trailText}`
+            ));
+
+            $list.appendChild($option);
+
+            if (isSelectedLine) {
+                this.#elements.$selectionDescription.textContent = option.description;
+            }
+        });
+
+        this.#elements.$list.replaceWith($list);
+        this.#elements.$list = $list; // Make sure the reference is updated too
+
+        if (activeMenu.escapeDisabled) {
+            this.#elements.$escapeMessage.classList.add("hidden");
+        } else {
+            this.#elements.$escapeMessage.classList.remove("hidden");
+        }
+    }
+
+    getItemIndex() {
+        const offset = this.getItemsPerPage() * this.#currentPage;
+        return offset + this.#selectionIndex;
+    }
+
+    refreshList() {
+        for (const $el of this.#elements.$list.children) {
+            if (! $el.classList.contains("option")) {
+                continue;
+            }
+
+            if (parseInt($el.dataset.index, 10) === this.#selectionIndex) {
+                $el.classList.add("selected");
+                const options = this.getActiveMenu().getOptions();
+                this.#elements.$selectionDescription.textContent =
+                    options[this.getItemIndex()].description;
+            } else if ($el.classList.contains("selected")) {
+                $el.classList.remove("selected");
+            }
+        };
+    }
+
+    handleInput(key) {
+        // @TODO Handle elsewhere
+        // if (animationActive) return;
+
+        const activeMenu = this.getActiveMenu();
+        const options = activeMenu.getOptions();
+        const itemsPerPage = this.getItemsPerPage();
+        const totalPages = Math.ceil(options.length / itemsPerPage);
+        const itemsOnCurrentPage = (this.#currentPage + 1) >= totalPages
+            ? ((options.length % itemsPerPage) || itemsPerPage)
+            : itemsPerPage;
+
+        switch (key) {
+            case 'escape':
+                this.goToPreviousMenu();
+                break;
+            case 'w':
+            case 'arrowup':
+                this.setSelection(
+                    this.#selectionIndex <= 0
+                        ? itemsOnCurrentPage - 1
+                        : this.#selectionIndex - 1
+                );
+                break;
+            case 's':
+            case 'arrowdown':
+                this.setSelection(
+                    this.#selectionIndex >= itemsOnCurrentPage - 1
+                        ? 0
+                        : this.#selectionIndex + 1
+                );
+                break;
+            case 'a':
+            case 'arrowleft':
+                if (this.#currentPage > 0) {
+                    this.#currentPage--;
+                    this.#selectionIndex = 0; // Reset selection index on page change
+                    this.render();
+                    this.#onHighlight?.();
+                }
+                break;
+            case 'd':
+            case 'arrowright':
+                if (this.#currentPage < totalPages - 1) {
+                    this.#currentPage++;
+                    this.#selectionIndex = 0; // Reset selection index on page change
+                    this.render();
+                    this.#onHighlight?.();
+                }
+                break;
+            case ' ':
+            case 'e':
+            case 'enter': {
+                this.select(this.#selectionIndex);
+                this.render();
+                break;
+            }
+        }
+    }
+
+    goToPreviousMenu() {
+        if (this.getActiveMenu()?.escapeDisabled) {
+            return;
+        }
+
+        this.close();
+        this.render();
+    }
+
+    setSelection(index) {
+        this.#selectionIndex = parseInt(index, 10);
+        this.refreshList();
+        this.#onHighlight?.();
+    }
+
+    select(index) {
+        const activeMenu = this.getActiveMenu();
+        const key = this.#currentPage * this.getItemsPerPage() + index;
+        const selectedOptionId = activeMenu.getOptions()?.[key]?.id;
+        if (selectedOptionId === '_back') {
+            this.close();
+        } else if (selectedOptionId === '_exitAll') {
+            this.closeAll();
+        } else {
+            activeMenu?.select(selectedOptionId, this);
+            this.#onSelect?.();
+        }
+
+        this.render();
+    }
+};

--- a/src/scripts/Tooltip.js
+++ b/src/scripts/Tooltip.js
@@ -1,0 +1,67 @@
+const Tooltip = {
+    delayTimeMs: 300,
+    timer: null,
+    display: (e) => {
+        const trigger = e.target;
+        const tooltip = trigger.querySelector("[role=tooltip]");
+        if (!tooltip) {
+            console.warn(
+                "Cannot display tooltip: no tooltip found",
+                { e }
+            );
+            return;
+        }
+
+        const { x, y, width, height } = trigger.getBoundingClientRect();
+
+        tooltip.style.left = `${Math.floor(x)}px`;
+        tooltip.style.top = `${Math.floor(y)}px`;
+        tooltip.classList.add("active");
+    },
+    hide: (e) => {
+        const tooltip = e.target.querySelector("[role=tooltip]");
+        if (!tooltip) {
+            console.warn(
+                "Cannot hide tooltip: no tooltip found",
+                { e }
+            );
+            return;
+        }
+        tooltip.classList.remove("active");
+    },
+    refresh: ($element) => {
+        if (!$element.dataset.tooltiphtml) {
+            console.warn("No tooltip data to refresh", { $element });
+            return;
+        }
+
+        if ($element.querySelector('div[role="tooltip"]')) {
+            console.warn("Element already has a tooltip", { $element });
+            return;
+        }
+
+        let tooltip = document.createElement("div");
+
+        tooltip.setAttribute("role", "tooltip");
+        tooltip.setAttribute("inert", true);
+        if ($element.dataset?.tooltipposition) {
+            tooltip.classList.add($element.dataset.tooltipposition);
+        }
+        tooltip.innerHTML = $element.dataset.tooltiphtml;
+
+        $element.appendChild(tooltip);
+
+        $element.addEventListener("mouseenter", (e) => {
+            clearTimeout(Tooltip.timer);
+
+            Tooltip.timer = setTimeout(() => {
+                Tooltip.display(e);
+            }, Tooltip.delayTimeMs);
+        });
+
+        $element.addEventListener("mouseleave", (e) => {
+            clearTimeout(Tooltip.timer);
+            Tooltip.hide(e);
+        });
+    },
+};


### PR DESCRIPTION
This PR aims to provide select performance improvements for the game through restructuring the map, minimap, battle log, and menu

## Map and Minimap Updates
This PR adjusts the map's functionality to wrap it into its own `Map` class which handles a lot of placement and rendering functionality with more ease

### Updating Map Cells
Previously, map cells were tracked in the global `MAP` array. `MAP` has now been converted to an instance of the `Map` class. This means that `MAP` still holds the contents of the game's map, but now has helper methods associated with it that can be used to perform operations on the map

In particular, we previously were setting map cells by creating new `MapCell()` objects in the array's coordinates:
```javascript
MAP[y][x] = new MapCell(...);
```

Now, we can set these with `Map.setCell()`:
```javascript
MAP.setCell(x, y, type);
```

This still uses `MapCell()` behind the scenes, but performs some handling, such as map boundary checks and initialization automatically

### Rendering Optimization
Previously, on each `render()` call, the minimap would be entirely discarded and recreated. This has become notably heavy after introducing tooltips which would require a handler to be reattached to all cells after clearing

Instead of refreshing everything, the `Map` class in this PR now only updates the cells of the minimap if they had changed since the last time. When a cell is updated via `Map.setCell()`, `Map.setEntities()`, `Map.initializeMinimap()`, `Map.revealSpot()`, or `Map.reveal()`, an internal `#rerenderList` is updated with the coordinates of the changed cell. On every `render()`, `Map.refreshMinimap()` is called which will cause only the cells located in the coordinates of the `#rerenderList` to be updated rather than the entire minimap. This cuts down significantly on the number of elements that are generated and discarded, making it easier for browsers to manage the state of the minimap

### Tracking Entities on the Map
The map can also track entities apart from the map's cells via `Map.setEntities()`. This is currently only used for the player, but will be used for NPCs in the future as well. `Map.setEntities()` takes an object keyed by entity ID that contains a pair of `x` and `y` coordinates as well as cell overrides that are used to replace the display of that cell in the minimap when rendered

These objects can also have a `forceRefresh` option which, if set to `true`, will force the entity to be refreshed on every render. This is currently enabled for the player character since turning in place will not cause the cell to be updated (therefore avoiding the cell being added to the aforementioned `#rerenderList`), though the player's character is an arrow that needs to be shown pointing in the correct direction at all times. This mechanism may be replaced with something more sophisticated in the future, though given that it's only used for the player character, is a minimal concern at this point

### Map Generation Logic Organization
The `Map` class now holds the bulk of the general map generation logic. `Map.generate()` will now generate a basic map with an entry and exit point

Beyond the general map structure, the facets of the map such as placing chests and traps are handled in the game's `generateMap()` function. This is because entity placement logic is specific to TardQuest, not to a generic game

### Elimination of Random Attempts
Placing floors and cells was previously performed by selecting random cells, seeing if they are empty, and placing entities in those spots. This is incredibly inefficient since most of the cells are not going to be empty, so scanning this way was particularly excessive

Now, the `Map` class has a `.getEmptyCellCoordinates()` method. This returns a list of all of the coordinates that are empty. Combining this with a new `shuffle()` method that randomizes the order of an array now makes it much simpler to find empty spots to place entities and objects around the map

## Battle Log Changes
The battle log was creating some extra work for browsers. This is because entries to the battle log would be tracked in an array. When updated, this array would be rescanned to generate the battle log messages, styling them based on their position to give a gradient effect

This has been replaced with simple logic that just prepends new lines to the battle log element. The gradient is now styled with CSS, so elements are no longer discarded and regenerated

## Menu System Updates
The menu system has been split off into its own `Menu` class. The way that the map is rendered has been modified to be less excessive. Basic mouse support has also been added to the menus, meaning that any given menu option can be hovered and clicked

### Menu Rendering
Like the minimap, the menus were constantly redrawn on `render()` calls. This includes when a selected option within the menu has changed. Because this resulted in a lot of needless regeneration and interfered with mouse events, the menu is now rendered only once when opened. Selecting options with the arrow keys or by hovering an option with the mouse cursor will now change the selected option internally and will simply change the option's class name in HTML to `selected` which determines which option is being pointed at with an arrow ("▶")

## Cracked Floor Updates
Previously, the cracked floor would be tracked and updated within `crackedFloorSteps`

This mechanism has been simplified by introducing a third type of floor: `Cracked Floor`. This now sits in between the other two:
1. `Slightly-Cracked Floor`
2. `Cracked Floor`
3. `Severely-Cracked Floor`

The logic for how these behave is now entirely stored within each of the cells' `onEnter()` callbacks.

The `player` object also now has a `player.getWeightLevel()` function that returns `normal`, `warning`, or `danger` depending on the player's weight percentage based on their carry and endurance levels

Together, the floor now breaks based on the following logic:
- `Slightly-Cracked Floor`...
  - ...becomes `Cracked Floor` when the player's weight level is `normal`
  - ...becomes `Severely-Cracked Floor` when the player's weight level is `warning`
  - ...breaks entirely if the player's weight level is `danger`
- `Cracked Floor`...
  - ...becomes `Severely-Cracked Floor` when the player's weight level is `normal`
  - ...breaks entirely if the player's weight level is either `warning` or `danger`
- `Severely-Cracked Floor` breaks if the player's weight level is `normal`, `warning`, or `danger`

## Misc Updates
- The game can now be started by clicking on the title screen
- Party member counts are now displayed in the Party section header
- The `Tooltip` class has been split into its own file
- Warnings from Edge's developer tools, namely `meta viewport` and `-webkit-user-select` (webkit doesn't support `user-select`, strangely), have been addressed
- The player's minimap tooltip now animates the player emoticon

## Other Notes
While this PR offers some performance improvements, there are still many to make in the scene renderer itself. This is being tracked under https://github.com/packardbell95/tardquest/issues/104