### PR TITLE
Ring of Sightliness Changes + Equipment menu combat limit

### DIFF
--- a/src/game.html
+++ b/src/game.html
@@ -8743,9 +8743,32 @@ A Javascript game by <a href="https://milklounge.wang/tardquest/" target="_blank
         }
 
         function updateSeenTiles() {
-             // Default reveal radius 1, 2 if Ring of Sightliness equipped
+            // Default reveal radius 1, 2 if Ring of Sightliness equipped
             const radius = player.hasEquippedRing('ringOfSightliness') ? 2 : 1;
-            MAP.revealSpot(player.x, player.y, radius);
+
+            if (player.hasEquippedRing('ringOfSightliness')) {
+                revealFOV(player.x, player.y, radius);
+            } else {
+                MAP.revealSpot(player.x, player.y, radius);
+            }
+        }
+
+        function revealFOV(px, py, radius) {
+            // Reveal the player's own tile
+            MAP.revealSpot(px, py, 0);
+
+            for (let angle = 0; angle < 360; angle += 5) {
+                const rad = angle * Math.PI / 180;
+                let blocked = false;
+                for (let r = 1; r <= radius; r++) {
+                    const tx = Math.round(px + Math.cos(rad) * r);
+                    const ty = Math.round(py + Math.sin(rad) * r);
+                    const cell = MAP.getCell(tx, ty);
+                    if (!cell) break;
+                    MAP.revealSpot(tx, ty, 0);
+                    if (cell.isSolid) break;
+                }
+            }
         }
 
         function updateBattleLog(entry) {
@@ -10202,6 +10225,8 @@ A Javascript game by <a href="https://milklounge.wang/tardquest/" target="_blank
                         id: "inventoryEquipment",
                         displayText: "Equipment",
                         description: "View and change your equipped weapon and armor.",
+                        className: player.inCombat ? "tooExpensive" : undefined,
+                        disabled: player.inCombat,
                     },
                     {
                         id: "_back",
@@ -10210,6 +10235,11 @@ A Javascript game by <a href="https://milklounge.wang/tardquest/" target="_blank
                     }
                 ],
                 select: (selectedOptionId) => {
+                    // When in battle, disable equipment submenu(s)
+                    if (selectedOptionId === "inventoryEquipment" && player.inCombat) {
+                        updateBattleLog("Your foe's deathly stare prevents you from wanting to strip down into a new set of equipment!");
+                        return;
+                    }
                     menu.open(selectedOptionId);
                 },
                 onOpen: () => {


### PR DESCRIPTION
A fairly simple set of small changes. The Ring of Sightliness will no longer allow you to see directly through walls, and basically just increases the player's FOV cone. Below is an annotated (maybe somewhat kinda inaccurate) screenshot of what the player's FOV cone looks like after equipping the ring, and what tiles are being revealed.
<img width="414" height="323" alt="fov" src="https://github.com/user-attachments/assets/70617262-b321-445a-87f3-ceee145c6bec" />

The equipment menu is also now inaccessible during combat, which was a decision made to reflect the upcoming clickable UI we have planned, complete with a bit of flavor text in the battle log.
<img width="1042" height="351" alt="battle-restriction" src="https://github.com/user-attachments/assets/04c03785-67e8-45ea-b36a-4bcbf15cbff0" />

This PR will close #65 
