### PR TITLE
Enhanced speech synthesis with pronunciation overrides and number handling

### DIFF
--- a/src/game.html
+++ b/src/game.html
@@ -6449,17 +6449,40 @@ A Javascript game by <a href="https://milklounge.wang/tardquest/" target="_blank
 
         const SpeechSynthesizer = {
             isSpeaking: false,
+            pronunciationOverrides: {
+                "gauge": "gayge",
+                "colonel": "kernel",
+                "queue": "cue",
+                "yacht": "yot",
+                "epitome": "eh pit oh mee",
+                "faq": "eff ay cue",
+                "jpeg": "jay peg",
+                "gif": "gif", // pronunciation debate
+                "regex": "rej ex",
+                "cache": "cash",
+                "gaol": "jail",
+                "ache": "ake",
+                "subtle": "suttle",
+                "victuals": "vittles",
+                "often": "offen",
+                "solder": "sodder",
+                "suite": "sweet",
+                "gouge": "gowj",
+            },
+
             speak: (sentence, voiceOptions, onEnded) => {
-                // Don't speak a new line if one is currently playing
                 if (!speechEnabled || SpeechSynthesizer.isSpeaking) {
                     onEnded?.();
                     return;
                 }
-
                 if (!voiceOptions) {
                     console.error("No voice options provided", { sentence });
                     return;
                 }
+
+                let normalizedSentence = SpeechSynthesizer.normalizeNumbers(sentence);
+                normalizedSentence = SpeechSynthesizer.expandAcronyms(normalizedSentence);
+                normalizedSentence = SpeechSynthesizer.applyPronunciationOverrides(normalizedSentence);
 
                 SpeechSynthesizer.isSpeaking = true;
                 const options = structuredClone(voiceOptions);
@@ -6475,11 +6498,167 @@ A Javascript game by <a href="https://milklounge.wang/tardquest/" target="_blank
                 options.onEnded = () => {
                     SpeechSynthesizer.isSpeaking = false;
                     onEnded?.();
-                }
+                };
 
-                new SamJs(options).speak(sentence);
+                new SamJs(options).speak(normalizedSentence);
             },
-        };
+
+            applyPronunciationOverrides: (text) => {
+                return text.replace(/\b([A-Za-z']+)\b/g, (m, w) => {
+                    const lower = w.toLowerCase();
+                    if (Object.hasOwn(SpeechSynthesizer.pronunciationOverrides, lower)) {
+                        const repl = SpeechSynthesizer.pronunciationOverrides[lower];
+                        if (w === w.toUpperCase()) {
+                            return /[\s-]/.test(repl) ? repl : repl.toUpperCase();
+                        }
+                        if (w[0] === w[0].toUpperCase()) {
+                            return repl.charAt(0).toUpperCase() + repl.slice(1);
+                        }
+                        return repl;
+                    }
+                    return m;
+                });
+            },
+
+            expandAcronyms: (text) => {
+                return text.replace(/\b([A-Z]{2,6})\b/g, (m, w) => {
+                    const lower = w.toLowerCase();
+                    // Skip if we have an explicit override (handled later) OR looks like a number mix
+                    if (Object.hasOwn(SpeechSynthesizer.pronunciationOverrides, lower)) return w;
+                    // Skip if next to apostrophes (possessives) – rare but safety
+                    if (/'/.test(w)) return w;
+                    // Split into spaced letters (SAM will spell them out)
+                    return w.split('').join(' ');
+                });
+            },
+
+            normalizeNumbers: (text) => {
+                // Pass 1: fractions
+                let out = text.replace(/(^|[^A-Za-z0-9+/-])([+-]?)(\d+)\s*\/\s*(\d+)(?=$|[^A-Za-z0-9/])/g,
+                    (full, pre, sign, numStr, denStr) => {
+                        const num = Number(numStr);
+                        const den = Number(denStr);
+                        if (!Number.isSafeInteger(num) || !Number.isSafeInteger(den) || den === 0) return full;
+                        if (numStr.length > 15 || denStr.length > 15) return full;
+                        const words = SpeechSynthesizer.fractionToWords(
+                            sign === '-' ? -1 : (sign === '+' ? 1 : 0),
+                            num,
+                            den
+                        );
+                        return pre + words;
+                    });
+
+                // Pass 2: decimals
+                out = out.replace(/(^|[^A-Za-z0-9.])([+-]?)(\d{1,3}(?:,\d{3})*|\d+)\.(\d+)(?=$|[^0-9.])/g,
+                    (full, pre, sign, intPart, fracPart) => {
+                        const cleanInt = intPart.replace(/,/g, '');
+                        if (cleanInt.length > 15 || fracPart.length > 30) return full;
+                        if (!/^\d+$/.test(cleanInt) || !/^\d+$/.test(fracPart)) return full;
+                        const intNum = Number(cleanInt);
+                        if (!Number.isSafeInteger(intNum) || intNum > 999_999_999_999) return full;
+                        return pre + SpeechSynthesizer.decimalToWords(sign, intNum, fracPart);
+                    });
+
+                // Pass 3: signed / unsigned integers
+                out = out.replace(/(^|[^A-Za-z0-9])([+-]?)(\d{1,3}(?:,\d{3})*|\d{1,15})(?=$|[^0-9])/g,
+                    (full, pre, sign, body) => {
+                        const clean = body.replace(/,/g, '');
+                        if (clean.length > 15) return full;
+                        if (!/^\d+$/.test(clean)) return full;
+                        const n = Number(clean);
+                        if (!Number.isSafeInteger(n) || n > 999_999_999_999) return full;
+                        return pre + SpeechSynthesizer.signedIntegerToWords(sign, n);
+                    });
+
+                return out;
+            },
+
+            signedIntegerToWords: (sign, n) => {
+                if (n === 0) return "zero";
+                const core = SpeechSynthesizer.numberToWordsLarge(n);
+                if (sign === '-') return `negative ${core}`;
+                if (sign === '+') return `positive ${core}`;
+                return core;
+            },
+
+            decimalToWords: (sign, intNum, fracStr) => {
+                const intWords = SpeechSynthesizer.numberToWordsLarge(intNum);
+                const fracDigits = fracStr.split('').map(d => SpeechSynthesizer.numberToWordsSmall(Number(d)));
+                const signWord = sign === '-' ? 'negative ' : (sign === '+' ? 'positive ' : '');
+                return `${signWord}${intWords} point ${fracDigits.join(' ')}`.replace(/\s+/g, ' ').trim();
+            },
+
+            fractionToWords: (signFlag, numerator, denominator) => {
+                // Reduce fraction
+                const gcd = (a, b) => b ? gcd(b, a % b) : a;
+                const g = gcd(numerator, denominator);
+                numerator = numerator / g;
+                denominator = denominator / g;
+
+                const signWord = signFlag < 0 ? 'negative ' : (signFlag > 0 ? 'positive ' : '');
+                const numWords = SpeechSynthesizer.numberToWordsLarge(numerator);
+                const denomWords = SpeechSynthesizer.fractionDenominatorToWords(denominator, numerator !== 1);
+
+                if (!denomWords) {
+                    const denomFallback = SpeechSynthesizer.numberToWordsLarge(denominator);
+                    return `${signWord}${numWords} over ${denomFallback}`.trim();
+                }
+                return `${signWord}${numWords} ${denomWords}`.trim();
+            },
+
+            fractionDenominatorToWords: (den, plural) => {
+                const map = {
+                    2: ['half', 'halves'],
+                    3: ['third', 'thirds'],
+                    4: ['fourth', 'fourths'],
+                    5: ['fifth', 'fifths'],
+                    6: ['sixth', 'sixths'],
+                    7: ['seventh', 'sevenths'],
+                    8: ['eighth', 'eighths'],
+                    9: ['ninth', 'ninths'],
+                    10: ['tenth', 'tenths'],
+                    11: ['eleventh', 'elevenths'],
+                    12: ['twelfth', 'twelfths'],
+                }[den];
+                if (!map) return null;
+                return plural ? map[1] : map[0];
+            },
+
+            numberToWordsSmall: (n) => {
+                const ones = [
+                    "zero","one","two","three","four","five","six","seven","eight","nine","ten",
+                    "eleven","twelve","thirteen","fourteen","fifteen","sixteen","seventeen","eighteen","nineteen"
+                ];
+                const tens = ["","","twenty","thirty","forty","fifty","sixty","seventy","eighty","ninety"];
+                if (n < 20) return ones[n];
+                if (n < 100) {
+                    const t = Math.floor(n / 10);
+                    const o = n % 10;
+                    return o ? `${tens[t]}-${ones[o]}` : tens[t];
+                }
+                const h = Math.floor(n / 100);
+                const r = n % 100;
+                return r ? `${ones[h]} hundred ${SpeechSynthesizer.numberToWordsSmall(r)}` : `${ones[h]} hundred`;
+            },
+
+            numberToWordsLarge: (n) => {
+                if (n === 0) return "zero";
+                const scales = ["", "thousand", "million", "billion", "trillion"];
+                const parts = [];
+                let scaleIndex = 0;
+                while (n > 0 && scaleIndex < scales.length) {
+                    const chunk = n % 1000;
+                    if (chunk) {
+                        const words = SpeechSynthesizer.numberToWordsSmall(chunk);
+                        const scaleWord = scales[scaleIndex];
+                        parts.unshift(scaleWord ? `${words} ${scaleWord}` : words);
+                    }
+                    n = Math.floor(n / 1000);
+                    scaleIndex++;
+                }
+                return parts.join(' ').replace(/\s+/g, ' ').trim();
+            },
+        };    
 
         const sceneRenderer = {
             displayWidth: 50,


### PR DESCRIPTION
### Changes

1. **Pronunciation Overrides**  
   - Added `pronunciationOverrides` dictionary for irregular words (e.g., "gauge" → "gayge")
   - Implemented case-preserving substitution in `applyPronunciationOverrides()`
   - Handles uppercase acronyms and title case words appropriately

2. **Acronym Expansion**  
   - `expandAcronyms()` converts letter groups to spaced letters ("EXP" → "E X P"). **_This may require further testing._**
   - Skips overridden terms and alphanumeric mixes
   - Preserves apostrophes in possessives

3. **Numeric Processing**  
   Three-stage normalization in `normalizeNumbers()`:
   - **Fractions**: `(a/b)` → verbalized ("3/4" → "three fourths")
     - Handles signs, reduces fractions, and supports large denominators
   - **Decimals**: `x.y` → verbalized ("12.34" → "twelve point three four")
     - Processes comma-separated integer parts
   - **Integers**: Full verbalization with sign support ("-1,024" → "negative one thousand twenty-four")

The changes maintain backward compatibility while significantly improving speech output quality.  

Fixes #110 