### PR TITLE
Unify input blocking + disable sidebar when input is blocked

### DIFF
--- a/src/game.html
+++ b/src/game.html
@@ -7923,7 +7923,10 @@ A Javascript game by <a href="https://milklounge.wang/tardquest/" target="_blank
             },
 
             disableControls: () => {
-                window._inputBlocked = true;
+                // Block input only if not awaiting persuasion text
+                if (!GameControl.awaitingPersuasionText) {
+                    window._inputBlocked = true;
+                }
                 GameControl.enabled = false;
                 // Disable inventory sidebar buttons while controls are disabled
                 if (typeof InventorySidebar !== 'undefined') {


### PR DESCRIPTION
### Main Changes:
- Moves `window._inputBlocked` flag into `GameControl`
- `GameControl.disableControls()` sets → `window._inputBlocked = true` 
- Checks for `awaitingPersuasionText` before setting `window._inputBlocked` (thanks to @TheMilkMan6669 for discovering this bug during testing)
- `GameControl.disableControls()` sets → `window._inputBlocked = false`
- All instances of `window._inputBlocked` have been changed to use `GameControl`
- Disables Inventory Sidebar when input is blocked

### Sidebar Blocking Demo:
![sidebar-demo](https://vocapepper.com/img/sidebar-blocking.gif)