### PR TITLE
Update Tooltip Handler

### DIFF
--- a/src/game.html
+++ b/src/game.html
@@ -686,13 +686,13 @@
             color: #f00;
         }
 
-        #minimap .vampire {
+        #minimap .vampire,
+        .mapCellDetails .enlargedTile.vampire {
             position: relative;
-            width: 1ch;
 
             &::before {
                 position: absolute;
-                left: 0;
+                left: calc(50% - (1ch / 2));
                 top: 0;
                 width: 1ch;
                 overflow: hidden;
@@ -701,6 +701,10 @@
                 animation: minimapVampireFlap 0.6s infinite;
                 color: #f0f;
             }
+        }
+
+        #minimap .vampire {
+            width: 1ch;
         }
 
         @keyframes minimapVampireFlap {
@@ -1492,21 +1496,21 @@
                 top 2px right -2px,
                 bottom -2px right -2px,
                 bottom -2px left 2px;
-        
+
             & .container {
                 top: 2px;
                 left: 2px;
-        
+
                 & .label {
                    background-color: transparent;
                 }
-        
+
                 & .icon {
                     filter: invert();
                 }
             }
         }
-        
+
         #inventory button:disabled {
             opacity: 0.25;
         }
@@ -1757,52 +1761,14 @@
 
         /* Tooltip styles */
         [role="tooltip"] {
-            opacity: 0;
-            position: absolute;
-            width: auto;
-            height: auto;
+            pointer-events: none;
             min-height: 25px;
             line-height: 25px;
             font-size: 1rem;
             background-color: #000d;
             color: #fff;
-            margin-top: 10px;
             padding: 4px;
-            transform: translateX(-50%);
-            z-index: 100; /* Appear over everything except title screen items */
-        }
-
-        [role="tooltip"].top {
-            transform: translateX(calc(-50% + 4.5px)) translateY(calc(-100% - 20px));
-        }
-
-        [role="tooltip"].bottom {
-            transform: translateX(calc(-50% + 4.5px)) translateY(15px);
-        }
-
-        [role="tooltip"].left {
-            transform: translateX(calc(-100% - 10px)) translateY(calc(-50% - 2.5px));
-        }
-
-        [role="tooltip"].right {
-            transform: translateX(18px) translateY(calc(-50% - 2.5px));
-        }
-
-        [role="tooltip"].active {
-            opacity: 1;
-            transition: opacity 0.1s;
-        }
-
-        [role="tooltip"]::before {
-            content: "";
-            width: 0;
-            height: 0;
-            border: 10px solid transparent;
-            border-top: 0;
-            position: absolute;
-            margin-top: -20px;
-            transform: translateX(-50%);
-            left: 50%;
+            box-shadow: 10px 10px 0 #0006;
         }
 
         .mapCellDetails {
@@ -1814,6 +1780,7 @@
         }
 
         .mapCellDetails .enlargedTile {
+            width: 40px;
             height: 40px;
             aspect-ratio: 1;
             display: flex;
@@ -1823,6 +1790,7 @@
             border: 2px solid #fff;
 
             &.vampire::before {
+                width: 40px;
                 line-height: 42px;
             }
         }
@@ -1862,6 +1830,35 @@
         .player.lets-go {
             display: inline-block;
             animation: letsGo .8s linear infinite;
+        }
+
+        .inventoryTooltip {
+            display: flex;
+            flex-direction: column;
+            padding: 10px;
+            border: 2px solid #fff;
+            max-width: 500px;
+        }
+
+        .inventoryTooltip .name {
+            font-size: 1.2em;
+        }
+
+        .inventoryTooltip .details {
+            display: flex;
+            flex-direction: column;
+        }
+
+        .playerInputTooltip {
+            padding: 0 1ch;
+            max-width: 500px;
+            border: 0;
+            color: #000;
+            background: #fff;
+
+            &.warning {
+                background: #ff0;
+            }
         }
 
         dialog.modal {
@@ -2559,32 +2556,68 @@ A Javascript game by <a href="https://milklounge.wang/tardquest/" target="_blank
                     <div id="navigationInput">
                         <button
                             name="turn-left"
-                            title="Turn Left"
+                            data-tooltipgroupid="playerInput"
+                            data-tooltipposition="top end"
+                            data-tooltiphtml='
+                                <div class="playerInputTooltip">
+                                    Turn Left
+                                </div>
+                            '
                             onclick="turnLeft()"
                         ></button>
                         <button
                             name="forward"
-                            title="Move Forward"
+                            data-tooltipgroupid="playerInput"
+                            data-tooltipposition="top end"
+                            data-tooltiphtml='
+                                <div class="playerInputTooltip">
+                                    Move Forward
+                                </div>
+                            '
                             onclick="move('forward')"
                         ></button>
                         <button
                             name="turn-right"
-                            title="Turn Right"
+                            data-tooltipgroupid="playerInput"
+                            data-tooltipposition="top end"
+                            data-tooltiphtml='
+                                <div class="playerInputTooltip">
+                                    Turn Right
+                                </div>
+                            '
                             onclick="turnRight()"
                         ></button>
                         <button
                             name="strafe-left"
-                            title="Strafe Left"
+                            data-tooltipgroupid="playerInput"
+                            data-tooltipposition="bottom end"
+                            data-tooltiphtml='
+                                <div class="playerInputTooltip">
+                                    Strafe Left
+                                </div>
+                            '
                             onclick="move('strafeLeft')"
                         ></button>
                         <button
                             name="backward"
-                            title="Move Backward"
+                            data-tooltipgroupid="playerInput"
+                            data-tooltipposition="bottom end"
+                            data-tooltiphtml='
+                                <div class="playerInputTooltip">
+                                    Move Backward
+                                </div>
+                            '
                             onclick="move('backward')"
                         ></button>
                         <button
                             name="strafe-right"
-                            title="Strafe Right"
+                            data-tooltipgroupid="playerInput"
+                            data-tooltipposition="bottom end"
+                            data-tooltiphtml='
+                                <div class="playerInputTooltip">
+                                    Strafe Right
+                                </div>
+                            '
                             onclick="move('strafeRight')"
                         ></button>
                     </div>
@@ -2596,17 +2629,32 @@ A Javascript game by <a href="https://milklounge.wang/tardquest/" target="_blank
                     <div id="battleInput">
                         <button
                             name="attack"
-                            title="KILL THAT SUCKA!"
+                            data-tooltipgroupid="playerInput"
+                            data-tooltiphtml='
+                                <div class="playerInputTooltip">
+                                    KILL THAT SUCKA!
+                                </div>
+                            '
                             onclick="playerAttack()"
                         ></button>
                         <button
                             name="persuade"
-                            title="Persuade the enemy to join your party"
+                            data-tooltipgroupid="playerInput"
+                            data-tooltiphtml='
+                                <div class="playerInputTooltip">
+                                    Persuade the enemy to join your party
+                                </div>
+                            '
                             onclick="tryPersuade()"
                         ></button>
                         <button
                             name="run"
-                            title="Run away like a coward"
+                            data-tooltipgroupid="playerInput"
+                            data-tooltiphtml='
+                                <div class="playerInputTooltip">
+                                    Run away like a coward
+                                </div>
+                            '
                             onclick="tryRun()"
                         ></button>
                     </div>
@@ -2617,30 +2665,55 @@ A Javascript game by <a href="https://milklounge.wang/tardquest/" target="_blank
                 <div class="grid-container">
                     <button
                         name="previous-page"
-                        title="Previous Page"
+                        data-tooltipgroupid="playerInput"
+                        data-tooltiphtml='
+                            <div class="playerInputTooltip">
+                                Previous Page
+                            </div>
+                        '
                         onclick="menu.previousPage()"
                         disabled="disabled"
                     ></button>
                     <div>
                         <button
                             name="up"
-                            title="Previous Option"
+                            data-tooltipgroupid="playerInput"
+                            data-tooltiphtml='
+                                <div class="playerInputTooltip">
+                                    Previous Option
+                                </div>
+                            '
                             onclick="menu.handleInput('arrowup')"
                         ></button>
                         <button
                             name="confirm"
-                            title="Confirm Selection"
+                            data-tooltipgroupid="playerInput"
+                            data-tooltiphtml='
+                                <div class="playerInputTooltip">
+                                    Confirm Selection
+                                </div>
+                            '
                             onclick="menu.handleInput('enter')"
                         ></button>
                         <button
                             name="down"
-                            title="Next Option"
+                            data-tooltipgroupid="playerInput"
+                            data-tooltiphtml='
+                                <div class="playerInputTooltip">
+                                    Next Option
+                                </div>
+                            '
                             onclick="menu.handleInput('arrowdown')"
                         ></button>
                     </div>
                     <button
                         name="next-page"
-                        title="Next Page"
+                        data-tooltipgroupid="playerInput"
+                        data-tooltiphtml='
+                            <div class="playerInputTooltip">
+                                Next Page
+                            </div>
+                        '
                         onclick="menu.nextPage()"
                         disabled="disabled"
                     ></button>
@@ -2678,6 +2751,16 @@ A Javascript game by <a href="https://milklounge.wang/tardquest/" target="_blank
     <script src="data/enemyart.js"></script>
     <script src="scripts/gamepad.js"></script>
     <script>
+        Tooltip.groupSettings = {
+            playerInput: {
+                delayMs: 800,
+                hideAfterInteraction: true,
+                position: "left",
+            },
+        };
+        document.querySelectorAll("#playerInput [data-tooltiphtml]")
+            .forEach(($e) => Tooltip.initialize($e));
+
         /**
          * ASCII art that the sceneRenderer uses to draw scenes
          *
@@ -8955,30 +9038,35 @@ A Javascript game by <a href="https://milklounge.wang/tardquest/" target="_blank
                             case "persuade":
                                 enabled = enabled && hasPersuasionAttempts;
                                 if (enabled) {
-                                    $button.setAttribute(
-                                        "title",
-                                        "Persuade the enemy to join your party"
-                                    );
+                                    $button.dataset.tooltiphtml = `
+                                        <div class="playerInputTooltip">
+                                            Persuade the enemy to join your
+                                            party
+                                        </div>
+                                    `;
                                 } else {
-                                    $button.setAttribute(
-                                        "title",
-                                        "Can't persuade the enemy to join " +
-                                        "your party!"
-                                    );
+                                    $button.dataset.tooltiphtml = `
+                                        <div class="playerInputTooltip warning">
+                                            Can't persuade the enemy to join
+                                            your party!
+                                        </div>
+                                    `;
                                 }
                                 break;
                             case "run":
                                 enabled = enabled && canRunAway;
                                 if (enabled) {
-                                    $button.setAttribute(
-                                        "title",
-                                        "Run away like a coward"
-                                    );
+                                    $button.dataset.tooltiphtml = `
+                                        <div class="playerInputTooltip">
+                                            Run away like a coward
+                                        </div>
+                                    `;
                                 } else {
-                                    $button.setAttribute(
-                                        "title",
-                                        "Can't run from this enemy!"
-                                    );
+                                    $button.dataset.tooltiphtml = `
+                                        <div class="playerInputTooltip warning">
+                                            Can't run from this enemy!
+                                        </div>
+                                    `;
                                 }
                                 break;
                             default:
@@ -12228,7 +12316,7 @@ A Javascript game by <a href="https://milklounge.wang/tardquest/" target="_blank
                 if (typeof callback === 'function') callback();
                 return;
             }
-            
+
             const container = document.getElementById('viewport');
             if (!container) return;
 
@@ -12796,7 +12884,7 @@ A Javascript game by <a href="https://milklounge.wang/tardquest/" target="_blank
                                 "You heard a scream, and the sound was " +
                                 "absolutely not faint."
                         ]);
-        
+
                         const enemyClassname =
                             currentEnemy?.displayClassName || "enemy";
                         updateBattleLog(
@@ -12923,22 +13011,22 @@ A Javascript game by <a href="https://milklounge.wang/tardquest/" target="_blank
             }, 168); // Reset after animation
         }
 
-        
+
         function animAsh(enemyId, onDone) {
             GameControl.disableControls(); // Block input during animation
             const $enemyLayer = document.querySelector('.layer.enemy');
             if (!$enemyLayer) return;
-        
+
             const $enemyPre = $enemyLayer.querySelector('pre');
             if (!$enemyPre) return;
-        
+
             // Get the ASCII art for the enemy
             const indexedArt = window.ENEMY_ART?.[enemyId];
             if (!indexedArt) { console.warn(`animAsh: No art found for enemyId "${enemyId}"`); return; }
-        
+
             // Format art and apply offsets (just like drawEnemyLayer)
             let art = sceneRenderer.formatArt(indexedArt);
-        
+
             // Apply horizontal offset if specified
             if (indexedArt.offsetX) {
                 art = art
@@ -12946,20 +13034,20 @@ A Javascript game by <a href="https://milklounge.wang/tardquest/" target="_blank
                     .map(line => ' '.repeat(indexedArt.offsetX) + line)
                     .join('\n');
             }
-        
+
             // Apply vertical offset if specified
             if (indexedArt.offsetY) {
                 art = '\n'.repeat(indexedArt.offsetY) + art;
             }
-        
+
             // Prepare the art as a 2D array
             let artLines = art.split('\n');
             let width = Math.max(...artLines.map(l => l.length));
             let height = artLines.length;
-        
+
             // Pad lines to equal width
             artLines = artLines.map(l => l.padEnd(width, ' '));
-        
+
             // Each cell: {char, y}
             let fragments = [];
             for (let y = 0; y < height; y++) {
@@ -12970,14 +13058,14 @@ A Javascript game by <a href="https://milklounge.wang/tardquest/" target="_blank
                     }
                 }
             }
-        
+
             // Animation loop
             let frame = 0;
             let maxFrames = height + 8;
             function draw() {
                 // Build empty grid
                 let grid = Array.from({ length: height }, () => Array(width).fill(' '));
-        
+
                 // Drop fragments
                 for (let frag of fragments) {
                     let below = frag.y + 1;
@@ -12986,10 +13074,10 @@ A Javascript game by <a href="https://milklounge.wang/tardquest/" target="_blank
                     }
                     grid[frag.y][frag.x] = frag.char;
                 }
-        
+
                 // Draw grid in the original <pre>
                 $enemyPre.textContent = grid.map(row => row.join('')).join('\n');
-        
+
                 frame++;
                 if (frame < maxFrames) {
                     requestAnimationFrame(draw);
@@ -15265,13 +15353,13 @@ A Javascript game by <a href="https://milklounge.wang/tardquest/" target="_blank
                     if (erok.isPetting) {
                         return;
                     }
-                    
+
                     if (selectedOptionId === "pet") {
                         erok.isPetting = true;
                         erok.say('holy crap oh my god pet me pet me oh my god holy shit oh god oh fuck oh god');
                         Portrait.show('erokPet');
                         menu.render();
-                        
+
                         // Timeout for when petting animation ends
                         setTimeout(() => {
                             erok.isPetting = false;
@@ -15763,10 +15851,19 @@ A Javascript game by <a href="https://milklounge.wang/tardquest/" target="_blank
                 const $button = document.createElement("button");
                 $button.className = `${sectionName}-${objectDefinition.id}`;
                 $button.dataset.id = objectDefinition.id;
+
                 $button.setAttribute(
-                    "title",
-                    `${objectDefinition.name}: ${objectDefinition.description}`
+                    'data-tooltipHtml',
+                    `<div class="inventoryTooltip">
+                        <div class="name">${objectDefinition.name}</div>
+                        <div class="details">
+                            ${objectDefinition.description}
+                        </div>
+                    </div>`
                 );
+                $button.setAttribute('data-tooltipPosition', 'left');
+                $button.setAttribute('data-tooltipGroupId', 'inventorySidebar');
+
                 // Reflect current enabled state on creation
                 if (!InventorySidebar.enabled) {
                     $button.setAttribute('disabled', 'true');
@@ -15787,6 +15884,7 @@ A Javascript game by <a href="https://milklounge.wang/tardquest/" target="_blank
                 $container.appendChild($icon);
                 $container.appendChild($label);
                 $button.appendChild($container);
+                Tooltip.initialize($button);
 
                 return $button;
             },
@@ -16226,7 +16324,7 @@ A Javascript game by <a href="https://milklounge.wang/tardquest/" target="_blank
                 luck: 0
             };
             player.levelUp();
-            
+
             // If auto diceroll enabled
             if (autoDicerollEnabled) {
                 rollDiceForLevelUp();
@@ -16317,19 +16415,19 @@ A Javascript game by <a href="https://milklounge.wang/tardquest/" target="_blank
                     const statKey = stat === "hp" ? "maxHp" : stat;
                     return levelUpStatPointsAllocated[statKey] < 2;
                 });
-                
+
                 if (availableStats.length === 0) break;
-                
+
                 const stat = randomEntry(availableStats);
                 const statKey = stat === "hp" ? "maxHp" : stat;
-                
+
                 if (stat === "hp") {
                     player.maxHp++;
                     player.hp = player.maxHp;
                 } else {
                     player[stat]++;
                 }
-                
+
                 levelUpStatPointsAllocated[statKey]++;
                 player.remainingPoints--;
             }
@@ -16598,6 +16696,22 @@ A Javascript game by <a href="https://milklounge.wang/tardquest/" target="_blank
                 }, 500);
             }, 500);
         }
+
+        document.querySelectorAll("#inventory > div[name]").forEach(($e) => {
+            const isScrollable = ["items", "weapons", "armor", "rings"]
+                .includes($e.getAttribute("name"));
+
+            if (! isScrollable) {
+                return;
+            }
+
+            addEventListener(
+                "wheel",
+                function (e) {
+                    $e.scrollTop += e.deltaY;
+                }
+            );
+        });
 
         document.addEventListener('keydown', function titleScreenHandler(e) {
             if ($titleScreen.style.display !== 'none' && (e.key === 'Enter' || e.key === ' ')) {

--- a/src/scripts/Map.js
+++ b/src/scripts/Map.js
@@ -98,6 +98,7 @@ class MapCell {
             );
 
             this.$element.setAttribute('data-tooltipPosition', 'right');
+            this.$element.setAttribute('data-tooltipGroupId', 'minimap');
         } else {
             console.warn("No coordinates found for cell", {
                 cellProperties,
@@ -109,7 +110,7 @@ class MapCell {
         }
 
         this.$element.innerText = tile;
-        Tooltip.refresh(this.$element);
+        Tooltip.initialize(this.$element);
     }
 
     static defaultsByType(type) {

--- a/src/scripts/Tooltip.js
+++ b/src/scripts/Tooltip.js
@@ -1,67 +1,440 @@
+/**
+ * Tooltip for TardQuest
+ *
+ * This is a custom helper that provides a flexible way to create tooltips
+ *
+ * USAGE
+ * To attach a tooltip to an element, the element must have a tooltipHtml data
+ * attribute associated with it which contains the contents of the tooltip. Then
+ * the element must be used to call Tooltip.initialize()
+ *
+ * Tooltip Data Attributes
+ * - tooltipHtml:       The HTML contents of the tooltip. This is required in
+ *                      order for the tooltip to work
+ *
+ * - tooltipPosition:   Where the tooltip should appear relative to the target
+ *                      element that's being hovered. Defaults to "right"
+ *
+ *                      The orthogonal positions have "start" and "end" variants
+ *                      which basically set the alignment of the tooltip in line
+ *                      with the triggering element. Otherwise, these are
+ *                      centered
+ *
+ *                      Acceptable values:
+ *                       - "right start"
+ *                       - "right"
+ *                       - "right end"
+ *                       - "left start"
+ *                       - "left"
+ *                       - "left end"
+ *                       - "top start"
+ *                       - "top"
+ *                       - "top end"
+ *                       - "bottom start"
+ *                       - "bottom"
+ *                       - "bottom end"
+ *                       - "top left"
+ *                       - "top right"
+ *                       - "bottom left"
+ *                       - "bottom right"
+ *
+ * - tooltipGroupId:    Name of an optional group that the tooltip belongs to.
+ *                      If a user activates two tooltips from the same group,
+ *                      the first one would be closed immediately and the second
+ *                      would appeaer immediately without fading out or in first
+ *
+ *
+ * Tooltip Group Settings
+ *
+ * Tooltip.groupSettings is an object whose keys are group identifiers (see
+ * tooltipGroupId above) and whose values are objects that may consist of the
+ * following optional parameters:
+ *
+ *  - delayMs:              The length of the delay in milliseconds after a
+ *                          target element is hovered before the tooltip starts
+ *                          to appear
+ *                          Default: 0
+ *
+ *  - hideAfterInteraction: A boolean flag that, when set to true, will suppress
+ *                          the tooltip for that group if the element has been
+ *                          clicked. This is used to minimize redundant tooltips
+ *                          for common interactions
+ *                          Default: false
+ *
+ *  - position:             The display position of the tooltip relative to its
+ *                          target. See "tooltipPosition" above for acceptable
+ *                          values. This can be overridden by setting the
+ *                          tooltipPosition attribute on the target element
+ *                          Default: "right"
+ */
 const Tooltip = {
-    delayTimeMs: 300,
-    timer: null,
-    display: (e) => {
-        const trigger = e.target;
-        const tooltip = trigger.querySelector("[role=tooltip]");
-        if (!tooltip) {
+    /** Public properties/methods **/
+    groupSettings: {},
+
+    /**
+     * Initializes a DOM element's tooltip interactions
+     *
+     * When called with an $element that has a `data-tooltiphtml` attribute,
+     * the element will have mouse handlers attached to it that will take care
+     * of the tooltip interactions automatically
+     *
+     * @param $element The DOM element receiving tooltip interactions
+     */
+    initialize: ($element) => {
+        if (! $element.dataset.tooltiphtml) {
+            console.warn("No tooltip data to initialize", { $element });
+            return;
+        }
+
+        if ($element.dataset.tooltipid) {
+            // Element already has a tooltip ID defined
+            return;
+        }
+
+        $element.dataset.tooltipid = `tq_tooltip_${crypto.randomUUID()}`;
+        $element.addEventListener("mouseenter", (e) => Tooltip._display(e));
+        $element.addEventListener("click", (e) => Tooltip._checkInteraction(e));
+        $element.addEventListener("mouseleave", (e) => Tooltip._hide(e));
+    },
+
+    /** Private properties/methods. Don't hook into or call these directly **/
+
+    _dismissalMs: 200,
+    _dismissedGroups: {},
+    _lastElementForGroup: {},
+    _lastGroupDisplayMs: {},
+    _lastGroupHideMs: {},
+
+    _getTooltip: ($target) => {
+        const $existingTooltip =
+            document.getElementById($target.dataset.tooltipid);
+        if ($existingTooltip) {
+            const animations = $existingTooltip.getAnimations();
+            if (animations.length > 0) {
+                animations[0].cancel();
+            }
+
+            return $existingTooltip;
+        }
+
+        const $tooltip = document.createElement("div");
+        $tooltip.id = $target.dataset.tooltipid;
+        $tooltip.setAttribute("role", "tooltip");
+        $tooltip.setAttribute("inert", true);
+        $tooltip.innerHTML = $target.dataset.tooltiphtml;
+        $tooltip.style.visibility = "hidden";
+        $tooltip.style.position = "absolute";
+        document.body.appendChild($tooltip);
+
+        const positions = Tooltip._getPosition($target, $tooltip);
+        $tooltip.style.top = `${positions.top}px`;
+        $tooltip.style.left = `${positions.left}px`;
+        $tooltip.style.removeProperty("visibility");
+
+        return $tooltip;
+    },
+
+    _groupedTooltipStillOpening: (groupId) => {
+        const delayMs = Tooltip.groupSettings?.[groupId]?.delayMs || 0;
+        if (! groupId || delayMs <= 0) {
+            return false;
+        }
+
+        const lastGroupDisplayMs =
+            Tooltip._lastGroupDisplayMs?.[groupId] || 0;
+        const timeSinceLastGroupDisplay =
+            performance.now() - lastGroupDisplayMs;
+        return timeSinceLastGroupDisplay < delayMs;
+    },
+
+    _updateGroup: ($target, $tooltip) => {
+        const tooltipId = $target.dataset?.tooltipid;
+        const groupId = $target.dataset?.tooltipgroupid;
+        if (! tooltipId || ! groupId) {
+            return true;
+        }
+
+        if (Tooltip._groupedTooltipStillOpening(groupId)) {
+            return false;
+        }
+
+        const recentlyHidden =
+            performance.now() - (Tooltip._lastGroupHideMs[groupId] || 0) >=
+            Tooltip._dismissalMs;
+        if (recentlyHidden) {
+            return false;
+        }
+
+        const lastTooltipId = Tooltip._lastElementForGroup?.[groupId];
+        Tooltip._lastElementForGroup[groupId] = tooltipId;
+
+        if (lastTooltipId && lastTooltipId !== tooltipId) {
+            document.getElementById(lastTooltipId)?.remove();
+            return true;
+        }
+
+        return false;
+    },
+
+    _groupDismissed: (groupId) => {
+        if (! groupId || ! Tooltip._dismissedGroups?.[groupId]) {
+            return false;
+        }
+
+        const lastDismissedMs =
+            performance.now() - (Tooltip._lastGroupHideMs[groupId] || 0);
+        return lastDismissedMs < Tooltip._dismissalMs;
+    },
+
+    _display: (e) => {
+        const $target = e.target;
+        const groupId = $target.dataset?.tooltipgroupid;
+
+        if (groupId) {
+            // Block the display if the group has been dismissed
+            if (Tooltip._groupDismissed(groupId)) {
+                return;
+            }
+
+            delete Tooltip._dismissedGroups[groupId];
+        }
+
+        const $tooltip = Tooltip._getTooltip($target);
+        const delayMs = parseInt(
+            Tooltip.groupSettings?.[groupId]?.delayMs ||
+            0,
+            10
+        );
+
+        $tooltip.style.zIndex = "100";
+        $tooltip.classList.add("active");
+
+        if (! Tooltip._updateGroup($target, $tooltip)) {
+            const animation = $tooltip.animate([
+                { opacity: 0, offset: 0, },
+                { opacity: 0, offset: delayMs / (delayMs + 200) },
+                { opacity: 1, offset: 1, }
+            ], {
+                duration: delayMs + 200,
+                fill: "forwards"
+            });
+
+            if (groupId) {
+                Tooltip._lastGroupDisplayMs[groupId] = performance.now();
+            }
+        }
+    },
+
+    _checkInteraction: (e) => {
+        const groupId = e.target.dataset?.tooltipgroupid;
+        if (! Tooltip.groupSettings?.[groupId]?.hideAfterInteraction) {
+            return;
+        }
+
+        Tooltip._dismissedGroups[groupId] = true;
+        Tooltip._hide(e);
+    },
+
+    _hide: (e) => {
+        const tooltipId = e.target?.dataset?.tooltipid;
+        if (! tooltipId) {
             console.warn(
-                "Cannot display tooltip: no tooltip found",
-                { e }
+                "Cannot hide tooltip: No tooltip ID exists on the target",
+                { target: e.target }
             );
             return;
         }
 
-        const { x, y, width, height } = trigger.getBoundingClientRect();
-
-        tooltip.style.left = `${Math.floor(x)}px`;
-        tooltip.style.top = `${Math.floor(y)}px`;
-        tooltip.classList.add("active");
-    },
-    hide: (e) => {
-        const tooltip = e.target.querySelector("[role=tooltip]");
-        if (!tooltip) {
-            console.warn(
-                "Cannot hide tooltip: no tooltip found",
-                { e }
-            );
-            return;
+        const groupId = e.target.dataset?.tooltipgroupid;
+        if (groupId) {
+            Tooltip._lastGroupHideMs[groupId] = performance.now();
         }
-        tooltip.classList.remove("active");
-    },
-    refresh: ($element) => {
-        if (!$element.dataset.tooltiphtml) {
-            console.warn("No tooltip data to refresh", { $element });
+
+        const $tooltip = document.getElementById(tooltipId);
+        if (! $tooltip) {
             return;
         }
 
-        if ($element.querySelector('div[role="tooltip"]')) {
-            console.warn("Element already has a tooltip", { $element });
+        // If the tooltip is still opening, skip the fadeout and just kill it
+        if (groupId && Tooltip._groupedTooltipStillOpening(groupId)) {
+            $tooltip.remove();
             return;
         }
 
-        let tooltip = document.createElement("div");
-
-        tooltip.setAttribute("role", "tooltip");
-        tooltip.setAttribute("inert", true);
-        if ($element.dataset?.tooltipposition) {
-            tooltip.classList.add($element.dataset.tooltipposition);
-        }
-        tooltip.innerHTML = $element.dataset.tooltiphtml;
-
-        $element.appendChild(tooltip);
-
-        $element.addEventListener("mouseenter", (e) => {
-            clearTimeout(Tooltip.timer);
-
-            Tooltip.timer = setTimeout(() => {
-                Tooltip.display(e);
-            }, Tooltip.delayTimeMs);
+        const animation = $tooltip.animate([
+            { opacity: 1, },
+            { opacity: 0, }
+        ], {
+            duration: 200,
+            fill: "forwards"
         });
 
-        $element.addEventListener("mouseleave", (e) => {
-            clearTimeout(Tooltip.timer);
-            Tooltip.hide(e);
-        });
+        animation.onfinish = function() {
+            $tooltip.remove();
+        };
+
+        $tooltip.classList.remove("active");
     },
+
+    _getPosition: ($target, $tooltip) => {
+        const tooltipRect = $tooltip.getBoundingClientRect();
+        const targetRect = $target.getBoundingClientRect();
+        const marginPx = parseInt($target.dataset?.tooltipmarginpx || 10, 10);
+        const groupId = $target.dataset?.tooltipgroupid;
+        const position = $target.dataset?.tooltipposition ||
+            Tooltip.groupSettings?.[groupId]?.position ||
+            "right";
+
+        switch (position) {
+            // Orthogonals
+            case "right start":
+                return {
+                    top:
+                        window.scrollY + targetRect.top,
+                    left:
+                        window.scrollX + targetRect.width + targetRect.left +
+                        marginPx,
+                };
+            case "right":
+                return {
+                    top:
+                        window.scrollY + targetRect.top +
+                        ((targetRect.height - tooltipRect.height) / 2),
+                    left:
+                        window.scrollX + targetRect.width + targetRect.left +
+                        marginPx,
+                };
+            case "right end":
+                return {
+                    top:
+                        window.scrollY + targetRect.top + targetRect.height -
+                        tooltipRect.height,
+                    left:
+                        window.scrollX + targetRect.width + targetRect.left +
+                        marginPx,
+                };
+
+            case "left start":
+                return {
+                    top:
+                        window.scrollY + targetRect.top,
+                    left:
+                        window.scrollX + targetRect.left - tooltipRect.width -
+                        marginPx,
+                };
+            case "left":
+                return {
+                    top:
+                        window.scrollY + targetRect.top +
+                        ((targetRect.height - tooltipRect.height) / 2),
+                    left:
+                        window.scrollX + targetRect.left - tooltipRect.width -
+                        marginPx,
+                };
+            case "left end":
+                return {
+                    top:
+                        window.scrollY + targetRect.top + targetRect.height -
+                        tooltipRect.height,
+                    left:
+                        window.scrollX + targetRect.left - tooltipRect.width -
+                        marginPx,
+                };
+
+            case "top start":
+                return {
+                    top:
+                        window.scrollY + targetRect.top - tooltipRect.height -
+                        marginPx,
+                    left:
+                        window.scrollX + targetRect.left,
+                };
+            case "top":
+                return {
+                    top:
+                        window.scrollY + targetRect.top - tooltipRect.height -
+                        marginPx,
+                    left:
+                        window.scrollX + targetRect.left +
+                        ((targetRect.width - tooltipRect.width) / 2),
+                };
+            case "top end":
+                return {
+                    top:
+                        window.scrollY + targetRect.top - tooltipRect.height -
+                        marginPx,
+                    left:
+                        window.scrollX + targetRect.left + targetRect.width -
+                        tooltipRect.width,
+                };
+
+            case "bottom start":
+                return {
+                    top:
+                        window.scrollY + targetRect.top + targetRect.height +
+                        marginPx,
+                    left:
+                        window.scrollX + targetRect.left,
+                };
+            case "bottom":
+                return {
+                    top:
+                        window.scrollY + targetRect.top + targetRect.height +
+                        marginPx,
+                    left:
+                        window.scrollX + targetRect.left +
+                        ((targetRect.width - tooltipRect.width) / 2),
+                };
+            case "bottom end":
+                return {
+                    top:
+                        window.scrollY + targetRect.top + targetRect.height +
+                        marginPx,
+                    left:
+                        window.scrollX + targetRect.left + targetRect.width -
+                        tooltipRect.width,
+                };
+
+            // Diagonals
+            case "top left":
+                return {
+                    top:
+                        window.scrollY + targetRect.top - tooltipRect.height -
+                        marginPx,
+                    left:
+                        window.scrollX + targetRect.left - tooltipRect.width -
+                        marginPx,
+                };
+            case "top right":
+                return {
+                    top:
+                        window.scrollY + targetRect.top - tooltipRect.height -
+                        marginPx,
+                    left:
+                        window.scrollX + targetRect.width + targetRect.left +
+                        marginPx,
+                };
+            case "bottom left":
+                return {
+                    top:
+                        window.scrollY + targetRect.top + targetRect.height +
+                        marginPx,
+                    left:
+                        window.scrollX + targetRect.left - tooltipRect.width -
+                        marginPx,
+                };
+            case "bottom right":
+                return {
+                    top:
+                        window.scrollY + targetRect.top + targetRect.height +
+                        marginPx,
+                    left:
+                        window.scrollX + targetRect.width + targetRect.left +
+                        marginPx,
+                };
+
+            default:
+                throw new Error(`Unrecognized position: ${position}`);
+        }
+    }
 };


### PR DESCRIPTION
> [!NOTE]
> This PR is pointing at the `add-vampire` branch 

This PR introduces changes that enhance the `Tooltip` object to prevent alignment issues and make it possible for tooltips to appear anywhere without being impeded by containing elements
This closes https://github.com/packardbell95/tardquest/issues/138

There is also an update to add mouse scroll functionality to the inventory sidebar. Equipment can now be scrolled with the mouse


### Screen Captures
| <img src="https://github.com/user-attachments/assets/641a6cc4-b380-4d3d-9fca-4d1bfb5c1cc7" width="300"> |
| --- |
| Tooltips now appear consistently in the minimap, including the previously-displaced vampire's tooltip |

| <img src="https://github.com/user-attachments/assets/d1de343e-2d58-4af7-aec5-650626661264" width="300"> |
| --- |
| Player input buttons now use tooltips instead of title text |

| <img src="https://github.com/user-attachments/assets/9e571e0d-d706-4bf1-85bd-2031c931d85a" width="300"> |
| --- |
| The inventory sidebar can now be scrolled with a mouse wheel. Item descriptions also now appear in tooltips instead of title text |


### Implementation Details
Previously, tooltips were created by attaching elements adjacent to the target elements that were being hovered. This meant that a tooltip would exist within the same container as the target that was calling it

This update takes a different approach: tooltips are tracked with uniquely-generated IDs and are placed in the document's body, so container interference is no longer an issue. The tooltips are then placed in absolute positions, using the target element's displayed size and coordinates to determine the position

#### About Tooltip Groups
Tooltips can also belong to groups that will help dictate behavior. For instance, all of the tooltips in the minimap belong to a "minimap" group. Grouped tooltips will only allow one tooltip from that group to appear at a time:

| <img src="https://github.com/user-attachments/assets/f77e5571-0ec1-4be9-998d-a7f60b76f4a0" width="300"> | <img src="https://github.com/user-attachments/assets/325964f2-9749-4d1e-8acf-c2a22228a570" width="300"> |
| --- | --- |
| **Grouped tooltips:** Only one tooltip appears at a time | **Ungrouped tooltips:** Creates redundant tooltips that cause a ghosting effect, plus lag due to the large number of elements being created and removed in a short timeframe |

Groups can also have defaults set, such as the `delayMs` which delays the appearance of a tooltip, the tooltip's `position`, and a `hideAfterInteraction` flag which will stop tooltips from appearing if the target element has been clicked


#### Test File
[This is the file I used](https://gist.github.com/packardbell95/0e04ed835d005885454595bdb9db4899) to figure out and test different positions. Place it in the project's `src` folder and open it for a demonstration