### PR TITLE
Preventing Viewport Overflow

### DIFF
--- a/src/game.html
+++ b/src/game.html
@@ -297,6 +297,7 @@
             );
             */
             background: linear-gradient(180deg,rgba(97, 0, 10, 1) 0%, rgba(0, 0, 0, 1) 30%, rgba(0, 0, 0, 1) 70%, rgba(117, 62, 0, 1) 100%);
+            overflow: hidden;
         }
 
         #game.terrain_iceCavern {


### PR DESCRIPTION
When holding a torch, the glow encroaches on the Viewport header. This PR stops that from happening

Closes https://github.com/packardbell95/tardquest/issues/123

| <img src="https://github.com/user-attachments/assets/a9a40d37-5c13-4f34-9d91-38c24d9f0d0a" width="300"> | <img src="https://github.com/user-attachments/assets/fd29d544-4978-474a-8e1c-95a206d32bf2" width="300"> |
| --- | --- |
| **Before:** Torch glow encroaching on the Viewport header | **After:** The glow is contained |

