### PR TITLE
Deleting tooltips when the sidebar button exhausts an item

### DIFF
--- a/src/game.html
+++ b/src/game.html
@@ -16070,6 +16070,13 @@ A Javascript game by <a href="https://milklounge.wang/tardquest/" target="_blank
                             player.inventory.useItem(item.id);
                             // Stop Enter from hitting the button again
                             this.blur();
+
+                            if (! player.inventory.hasItem(item.id)) {
+                                const id = $button?.dataset?.tooltipid;
+                                if (id) {
+                                    document.getElementById(id)?.remove();
+                                }
+                            }
                         };
 
                         $items.appendChild($button);


### PR DESCRIPTION
When using items in the sidebar, an item's button in the sidebar will be removed when the player no longer has any more. However, any tooltip reference that still exists will not be freed, so the tooltip on the page will persist since nothing exists to dismiss it

This PR fixes the problem by deleting the tooltip reference if the last of an item was used

| <img src="https://github.com/user-attachments/assets/4ce69977-1471-431b-b342-0b041d37c0ed" width="300"> |
| --- |
| Tooltips now being cleared after using up items |


Closes https://github.com/packardbell95/tardquest/issues/142