### PR TITLE
Fixing Title ScreenIinputs

### DIFF
--- a/src/data/title-screen.js
+++ b/src/data/title-screen.js
@@ -4,15 +4,20 @@
  * USAGE
  *
  * Display the title screen
- *  TITLE_SCREEN.initialize($e)
- *  where $e is the title screen's container element
+ *  TITLE_SCREEN.initialize($e, startGameFunction)
+ *  where $e is the title screen's container element and onStartGameClick is
+ *  called when the "Press [ENTER]..." message is clicked
  *
  * Hide the title screen
  *  TITLE_SCREEN.startGame($e, callback)
  *  where $e is the title screen's container and callback is fired after closing
  */
 const TITLE_SCREEN = {
+    // bool True if the title screen is active
     isActive: false,
+
+    // bool True if the title screen is actively starting the game
+    isStarting: false,
 };
 
 TITLE_SCREEN.logo = Object.freeze({
@@ -866,7 +871,7 @@ TITLE_SCREEN.distantLightning = {
 };
 
 TITLE_SCREEN.content = {
-    build: () => {
+    build: (onStartGameClick) => {
         const $content = document.createElement("div");
         $content.append(TITLE_SCREEN.logo.build());
 
@@ -877,6 +882,11 @@ TITLE_SCREEN.content = {
             <div>to begin your descent into</div>
             <div>the TardSpire...</div>
         `;
+
+        if (typeof onStartGameClick === "function") {
+            $startGameButton.onclick = onStartGameClick;
+        };
+
         $content.append($startGameButton);
 
         const $preloaderStatus = document.createElement("div");
@@ -942,7 +952,7 @@ TITLE_SCREEN.credits = {
     },
 };
 
-TITLE_SCREEN.initialize = ($e) => {
+TITLE_SCREEN.initialize = ($e, onStartGameClick) => {
     if (! $e instanceof Element) {
         console.error("The title screen target is not an element", { $e });
         return;
@@ -956,7 +966,7 @@ TITLE_SCREEN.initialize = ($e) => {
 
     $e.append(TITLE_SCREEN.distantLightning.build());
     $e.append(TITLE_SCREEN.lightning.build());
-    $e.append(TITLE_SCREEN.content.build());
+    $e.append(TITLE_SCREEN.content.build(onStartGameClick));
     $e.append(TITLE_SCREEN.credits.build());
 
     TITLE_SCREEN.starfield.initialize();
@@ -964,10 +974,12 @@ TITLE_SCREEN.initialize = ($e) => {
 };
 
 TITLE_SCREEN.startGame = ($e, callback) => {
-    if (! TITLE_SCREEN.isActive) {
+    if (! TITLE_SCREEN.isActive || TITLE_SCREEN.isStarting) {
         // The title screen isn't active, so there's nothing to do
         return;
     }
+
+    TITLE_SCREEN.isStarting = true;
 
     if (! $e instanceof Element) {
         console.warn("The title screen target is not an element", { $e });
@@ -989,6 +1001,7 @@ TITLE_SCREEN.startGame = ($e, callback) => {
             $e.classList.add("hidden");
             $e.replaceChildren();
             TITLE_SCREEN.isActive = false;
+            TITLE_SCREEN.isStarting = false;
             if (typeof callback === "function") {
                 callback();
             }

--- a/src/game.html
+++ b/src/game.html
@@ -17,7 +17,7 @@
     <div id="titleScreen" class="hidden"></div>
     <div id="vampireFocalPoint"></div>
     <div id="vampireFocalPointDesaturationOverlay"></div>
-    <div id="interface">
+    <div id="interface" class="hidden">
         <div id="animDamageTaken"></div>
         <div id="battleLog"></div>
         <div id="topLeft">
@@ -6676,7 +6676,7 @@
         })();
 
         const GameControl = {
-            mode: null,
+            mode: "title screen",
             enabled: true,
             awaitingPersuasionText: false,
 
@@ -6703,8 +6703,19 @@
                 GameControl.update();
             },
 
+            getMode: () => {
+                if (TITLE_SCREEN.isActive) {
+                    return "title screen";
+                }
+
+                return menu.isOpen()
+                    ? "menu"
+                    : (player.inCombat ? "combat" : "navigation");
+            },
+
             updateMode: () => {
                 const skipModeUpdate =
+                    ! TITLE_SCREEN.isActive &&
                     ( GameControl.mode === "menu" && menu.isOpen()) ||
                     ! menu.isOpen() && (
                         ( GameControl.mode === "navigation" && !player.inCombat ) ||
@@ -6715,9 +6726,7 @@
                     return;
                 }
 
-                GameControl.mode = menu.isOpen()
-                    ? "menu"
-                    : (player.inCombat ? "combat" : "navigation");
+                GameControl.mode = GameControl.getMode();
 
                 // Update the displayed buttons based on the mode
                 document.querySelectorAll(`
@@ -6793,6 +6802,9 @@
                 GameControl.updateMode();
 
                 switch (GameControl.mode) {
+                    case "title screen":
+                        // Nothing to do
+                        break;
                     case "navigation":
                         GameControl.updateNavigationControls();
                         break;
@@ -10368,7 +10380,9 @@
             }
 
             const container = document.getElementById('viewport');
-            if (!container) return;
+            if (!container) {
+                return;
+            }
 
             GameControl.disableControls();
 
@@ -14896,10 +14910,14 @@
 
         function hideTitleScreen() {
             music.stop();
+
+            // @TODO Refactor this since it's duplicated in gamepad.js
+            // @see https://github.com/packardbell95/tardquest/issues/162
             TITLE_SCREEN.startGame(
                 $titleScreen,
                 () => {
                     const $interface = document.getElementById("interface");
+                    $interface.classList.remove("hidden");
                     $interface.classList.add("reveal");
 
                     setTimeout(() => {
@@ -14938,17 +14956,19 @@
         }, true);
 
         if (skipTitleScreen) {
-            if (!preloaderEnabled) {
+            const onGameReady = () => {
+                document.getElementById("interface").classList.remove("hidden");
                 hideTitleScreen();
+            };
+
+            if (!preloaderEnabled) {
+                onGameReady();
             } else {
-                window.onTardquestLoaded = function() {
-                    hideTitleScreen();
-                };
+                window.onTardquestLoaded = onGameReady;
             }
         } else {
             music.play("title");
-            GameControl.disableControls();
-            TITLE_SCREEN.initialize($titleScreen);
+            TITLE_SCREEN.initialize($titleScreen, hideTitleScreen);
         }
 
         player.party.initializePartySection();

--- a/src/scripts/preloader-v2.js
+++ b/src/scripts/preloader-v2.js
@@ -282,12 +282,6 @@
                 navigator.serviceWorker.controller.postMessage({ type:'CACHE_PROBE', urls: STATIC_MANIFEST });
             }
         }catch(_e){}
-        // Hook start button to existing title/hide handler if present.
-        try{
-            const btn = document.getElementById('startGameBtn');
-            const hts = window.hideTitleScreen || window.hideTitleScreen?.bind?.(window);
-            if (btn && typeof hts === 'function') btn.onclick = hts;
-        }catch(_e){}
         // Game entry callback
         try{
             if (typeof window.onTardquestLoaded === 'function') window.onTardquestLoaded();


### PR DESCRIPTION
This PR includes a few title screen fixes:
- The game can now be started from the gamepad once again
- Menu buttons with the gamepad are now fixed
- The "Press Enter" click handler on the title screen is no longer reliant on the preloader's status and will always fire when clicked
- Fixed a display issue where the game's main interface could sometimes be seen briefly before the title screen is shown on load

Closes https://github.com/packardbell95/tardquest/issues/160