### PR TITLE
Update client API integrations for v4 server

### DIFF
--- a/src/scripts/pigeon.js
+++ b/src/scripts/pigeon.js
@@ -135,7 +135,7 @@
             return false;
         }
         try {
-            const r = await fetch(`${TardAPI.API_BASE}/api/pigeon/send`, {
+            const r = await fetch(`${TardAPI.API_BASE}/pigeon/send`, {
                 method:'POST',
                 headers:{'Content-Type':'application/json'},
                 body: JSON.stringify({ session_id: sid, message })
@@ -158,6 +158,10 @@
                 }
                 return true;
             } else {
+                if (TardAPI.isSessionInvalidError(j.error)) {
+                    log.warn('Session invalid during send, clearing stale session');
+                    TardAPI.clearSession();
+                }
                 updateBattleLog(`<span class="enemy">Pigeon failed: ${j.error||'Unknown error'}</span>`);
                 log.warn('Send failed!', r.status, j);
                 return false;
@@ -231,7 +235,7 @@
             return Promise.resolve(false);
         }
 
-        return fetch(`${TardAPI.API_BASE}/api/pigeon/murder`, {
+        return fetch(`${TardAPI.API_BASE}/pigeon/murder`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ SID: sid, session_id: sid })
@@ -239,6 +243,10 @@
         .then(r => r.json().catch(() => ({})).then(j => ({ ok: r.ok, j })))
         .then(({ ok, j }) => {
             if (!ok) {
+                if (TardAPI.isSessionInvalidError(j.error)) {
+                    log.warn('Session invalid during murder report, clearing stale session');
+                    TardAPI.clearSession();
+                }
                 log.warn('Murder report failed', j);
                 return false;
             }
@@ -263,12 +271,19 @@
         if (!sid) return;
         lastDeliveryAttempt = now;
         try {
-            const r = await fetch(`${TardAPI.API_BASE}/api/pigeon/delivery`, {
+            const r = await fetch(`${TardAPI.API_BASE}/pigeon/delivery`, {
                 method:'POST',
                 headers:{'Content-Type':'application/json'},
                 body: JSON.stringify({ session_id: sid })
             });
             const data = await r.json().catch(()=>({}));
+            if (TardAPI.isSessionInvalidError(data.error)) {
+                // Don't clear the session here — pigeon delivery is background polling
+                // and the session may still be valid for other endpoints. The main
+                // updateProgress/submitScore flows will handle stale-session cleanup.
+                log.warn('Delivery failed (session not found on server) — will retry later');
+                return;
+            }
             if (data && data.pigeon_message) {
                 log.info('Received Message ID:', data.pigeon_id || 'n/a');
                 stopPolling(); // Pause polling until message is displayed

--- a/src/scripts/tardAPI.js
+++ b/src/scripts/tardAPI.js
@@ -23,10 +23,10 @@ const TardAPI = (function() {
     // --- Configuration ---
 
     /** @const {string} Base URL for all API endpoints */
-    const API_BASE = 'https://vocapepper.com:9601';
+    const API_BASE = 'https://gateway.tardquest.online';
 
     /** @const {string} Client API version (major.minor must match server) */
-    const CLIENT_API_VERSION = '3.2.260315';
+    const CLIENT_API_VERSION = '4.0.2606';
 
     /** @const {string} LocalStorage key for session ID persistence */
     const LS_SESSION_KEY = 'tardquestSID';
@@ -36,6 +36,9 @@ const TardAPI = (function() {
 
     /** @const {string} LocalStorage key for API feature toggle */
     const LS_API_FEATURES_KEY = 'tardquestApiFeaturesEnabled';
+
+    /** @const {string} LocalStorage key for authenticated account username */
+    const LS_ACCOUNT_KEY = 'tardquestAccountUser';
 
     // --- Logging Utility ---
 
@@ -50,6 +53,11 @@ const TardAPI = (function() {
 
     /** @type {string|null} Current session ID */
     let sessionId = sessionStorage.getItem(LS_SESSION_KEY) || null;
+
+    /** @type {string|null} Authenticated account username (null for guest sessions) */
+    let authUsername = (function() {
+        try { return localStorage.getItem(LS_ACCOUNT_KEY) || null; } catch { return null; }
+    })();
 
     /** @type {Object|null} Current PoW challenge data */
     let challengeData = null;
@@ -239,7 +247,7 @@ const TardAPI = (function() {
         }
 
         try {
-            const res = await fetch(`${API_BASE}/api/status`, { method: 'GET', mode: 'cors' });
+            const res = await fetch(`${API_BASE}/status`, { method: 'GET', mode: 'cors' });
             return res.ok;
         } catch {
             return false;
@@ -297,7 +305,7 @@ const TardAPI = (function() {
 
         try {
             log.info('Creating new session...');
-            const res = await fetch(`${API_BASE}/api/start`, {
+            const res = await fetch(`${API_BASE}/start`, {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({ version: CLIENT_API_VERSION })
@@ -320,27 +328,7 @@ const TardAPI = (function() {
             sessionStorage.setItem(LS_SESSION_KEY, sessionId);
             log.info('Session created:', sessionId);
 
-            // Store PoW challenge if provided
-            const challengeSalt = data.challenge_salt || null;
-            const challengeDifficulty = Number.isFinite(Number(data.challenge_difficulty))
-                ? Math.max(1, Math.min(8, Math.floor(Number(data.challenge_difficulty))))
-                : 4;
-
-            if (data.challenge_secret) {
-                // Intentionally ignored: this is from the old PoW system,
-                // which will still be supported by the server for a transitional period.
-                log.warn('Ignoring legacy challenge_secret from /api/start response');
-            }
-
-            if (data.challenge_id && challengeSalt) {
-                challengeData = {
-                    challenge_id: data.challenge_id,
-                    challenge_salt: challengeSalt,
-                    challenge_difficulty: challengeDifficulty
-                };
-                sessionStorage.setItem(LS_CHALLENGE_KEY, JSON.stringify(challengeData));
-                log.info('PoW challenge received (difficulty', challengeDifficulty + ')');
-            }
+            storeChallengeFromResponse(data);
 
             // Reset game state tracking
             const state = getGameState();
@@ -364,6 +352,19 @@ const TardAPI = (function() {
 
     /**
      * Validates current session with the API
+    /**
+     * Checks whether an error string indicates an invalid or expired session.
+     * @param {string} errorMsg - Error message from the API response
+     * @returns {boolean} True if the session is invalid/expired
+     */
+    function isSessionInvalidError(errorMsg) {
+        if (!errorMsg) return false;
+        const lower = String(errorMsg).toLowerCase();
+        return lower.includes('invalid session') || lower.includes('session expired');
+    }
+
+    /**
+     * Validates current session with the API
      * Returns the session data if valid
      * @returns {Promise<Object>} Validation result with session status
      */
@@ -377,16 +378,21 @@ const TardAPI = (function() {
         }
 
         try {
-            const { floor, level } = getGameState();
-            const res = await fetch(`${API_BASE}/api/update`, {
+            const { floor, level, totalExp } = getGameState();
+            const res = await fetch(`${API_BASE}/update`, {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ session_id: sessionId, floor, level })
+                body: JSON.stringify({ session_id: sessionId, floor, level, exp: totalExp })
             });
 
             if (!res.ok) {
                 const data = await res.json().catch(() => ({}));
-                return { success: false, error: data.error || `HTTP ${res.status}` };
+                const errMsg = data.error || `HTTP ${res.status}`;
+                if (isSessionInvalidError(errMsg)) {
+                    log.warn('Session invalid/expired, clearing for re-creation');
+                    clearSession();
+                }
+                return { success: false, error: errMsg };
             }
 
             const data = await res.json();
@@ -437,7 +443,7 @@ const TardAPI = (function() {
             }
 
             // Update server
-            const res = await fetch(`${API_BASE}/api/update`, {
+            const res = await fetch(`${API_BASE}/update`, {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({ session_id: sessionId, floor, level, exp: totalExp })
@@ -461,6 +467,10 @@ const TardAPI = (function() {
             firstSessionAttemptTime = null;
             return { success: true, data };
         } catch (err) {
+            if (isSessionInvalidError(err.message)) {
+                log.warn('Session invalid/expired, clearing for re-creation');
+                clearSession();
+            }
             log.error(`Session creation failed (attempt ${sessionAttempts}/${MAX_SESSION_ATTEMPTS}):`, err.message);
             return { success: false, error: err.message };
         } finally {
@@ -469,13 +479,11 @@ const TardAPI = (function() {
     }
 
     /**
-     * Submits a leaderboard score with optional PoW validation
+     * Submits a leaderboard score with PoW validation
      * @param {string} name - Player name (max 5 characters)
-     * @param {Object} options - Additional submission options
-     * @param {string} [options.captcha_token] - Captcha token for verification
      * @returns {Promise<Object>} Submission result
      */
-    async function submitScore(name, options = {}) {
+    async function submitScore(name) {
         if (!apiFeaturesEnabled) {
             return getApiDisabledResult();
         }
@@ -500,12 +508,7 @@ const TardAPI = (function() {
                 body.challenge_proof = proof;
             }
 
-            // Add captcha token if provided
-            if (options.captcha_token) {
-                body.captcha_token = options.captcha_token;
-            }
-
-            const res = await fetch(`${API_BASE}/api/leaderboard`, {
+            const res = await fetch(`${API_BASE}/leaderboard`, {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify(body)
@@ -513,7 +516,12 @@ const TardAPI = (function() {
 
             if (!res.ok) {
                 const data = await res.json().catch(() => ({}));
-                return { success: false, error: data.error || `HTTP ${res.status}` };
+                const errMsg = data.error || `HTTP ${res.status}`;
+                if (isSessionInvalidError(errMsg)) {
+                    log.warn('Session invalid/expired, clearing for re-creation');
+                    clearSession();
+                }
+                return { success: false, error: errMsg };
             }
 
             const data = await res.json();
@@ -554,8 +562,8 @@ const TardAPI = (function() {
             if (limit) params.append('limit', String(limit));
 
             const url = params.toString()
-                ? `${API_BASE}/api/leaderboard?${params.toString()}`
-                : `${API_BASE}/api/leaderboard`;
+                ? `${API_BASE}/leaderboard?${params.toString()}`
+                : `${API_BASE}/leaderboard`;
 
             log.info('Fetching leaderboard from', url);
             const res = await fetch(url, { method: 'GET', mode: 'cors' });
@@ -622,11 +630,196 @@ const TardAPI = (function() {
     function clearSession() {
         sessionId = null;
         challengeData = null;
+        authUsername = null;
         lastFloor = 1;
         lastLevel = 1;
         sessionStorage.removeItem(LS_SESSION_KEY);
         sessionStorage.removeItem(LS_CHALLENGE_KEY);
+        try { localStorage.removeItem(LS_ACCOUNT_KEY); } catch {}
         log.info('Session cleared');
+    }
+
+    // --- Account / Auth ---
+
+    function storeChallengeFromResponse(data) {
+        const challengeSalt = data.challenge_salt || null;
+        const challengeDifficulty = Number.isFinite(Number(data.challenge_difficulty))
+            ? Math.max(1, Math.min(8, Math.floor(Number(data.challenge_difficulty))))
+            : 4;
+
+        if (data.challenge_id && challengeSalt) {
+            challengeData = {
+                challenge_id: data.challenge_id,
+                challenge_salt: challengeSalt,
+                challenge_difficulty: challengeDifficulty
+            };
+            sessionStorage.setItem(LS_CHALLENGE_KEY, JSON.stringify(challengeData));
+            log.info('PoW challenge received (difficulty', challengeDifficulty + ')');
+        }
+    }
+
+    /**
+     * Logs in with an account credential. Creates an authenticated API session.
+     * @param {string} username - Account username
+     * @param {string} password - Account password
+     * @returns {Promise<Object>} { success, session_id?, username?, error? }
+     */
+    async function login(username, password) {
+        if (!apiFeaturesEnabled) {
+            return getApiDisabledResult();
+        }
+        try {
+            const res = await fetch(`${API_BASE}/auth/login`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ username, password })
+            });
+            const data = await res.json().catch(() => ({}));
+            if (!res.ok) {
+                return { success: false, error: data.error || `HTTP ${res.status}` };
+            }
+            if (!data.session_id) {
+                return { success: false, error: 'Server did not return session_id' };
+            }
+            sessionId = data.session_id;
+            sessionStorage.setItem(LS_SESSION_KEY, sessionId);
+            authUsername = data.username || username;
+            try { localStorage.setItem(LS_ACCOUNT_KEY, authUsername); } catch {}
+            storeChallengeFromResponse(data);
+            log.info('Account login successful:', authUsername);
+            return { success: true, session_id: sessionId, username: authUsername };
+        } catch (err) {
+            log.error('Login failed:', err.message);
+            return { success: false, error: err.message };
+        }
+    }
+
+    /**
+     * Registers a new account. Does NOT auto-login.
+     * @param {string} username - Desired username
+     * @param {string} password - Desired password
+     * @returns {Promise<Object>} { success, error? }
+     */
+    async function register(username, password) {
+        if (!apiFeaturesEnabled) {
+            return getApiDisabledResult();
+        }
+        try {
+            const res = await fetch(`${API_BASE}/auth/register`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ username, password })
+            });
+            const data = await res.json().catch(() => ({}));
+            if (!res.ok) {
+                return { success: false, error: data.error || `HTTP ${res.status}` };
+            }
+            log.info('Account registered:', username);
+            return { success: true };
+        } catch (err) {
+            log.error('Registration failed:', err.message);
+            return { success: false, error: err.message };
+        }
+    }
+
+    /**
+     * Logs out: clears the local session and account state.
+     */
+    function logout() {
+        clearSession();
+        log.info('Account logged out');
+    }
+
+    /**
+     * Verifies the current session's auth status with the server.
+     * @returns {Promise<Object>} { success, authenticated, username? }
+     */
+    async function checkAuth() {
+        if (!sessionId) {
+            return { success: false, authenticated: false };
+        }
+        try {
+            const res = await fetch(`${API_BASE}/auth/status`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ session_id: sessionId })
+            });
+            const data = await res.json().catch(() => ({}));
+            if (!res.ok) {
+                if (data.error && (data.error.includes('expired') || data.error.includes('Invalid'))) {
+                    clearSession();
+                }
+                return { success: false, authenticated: false };
+            }
+            if (data.authenticated && data.username) {
+                authUsername = data.username;
+                try { localStorage.setItem(LS_ACCOUNT_KEY, authUsername); } catch {}
+            } else if (!data.authenticated) {
+                authUsername = null;
+                try { localStorage.removeItem(LS_ACCOUNT_KEY); } catch {}
+            }
+            return { success: true, authenticated: !!data.authenticated, username: data.username || null };
+        } catch (err) {
+            log.error('Auth check failed:', err.message);
+            return { success: false, authenticated: false };
+        }
+    }
+
+    /**
+     * Rotates (regenerates) recovery codes for the authenticated account.
+     * @param {string} password - Current account password for re-verification
+     * @returns {Promise<Object>} { success, codes?, error? }
+     */
+    async function rotateRecoveryCodes(password) {
+        if (!apiFeaturesEnabled) {
+            return getApiDisabledResult();
+        }
+        if (!sessionId) {
+            return { success: false, error: 'No active session' };
+        }
+        try {
+            const res = await fetch(`${API_BASE}/auth/recovery-codes/rotate`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ session_id: sessionId, password })
+            });
+            const data = await res.json().catch(() => ({}));
+            if (!res.ok) {
+                return { success: false, error: data.error || `HTTP ${res.status}` };
+            }
+            return { success: true, codes: data.codes || [] };
+        } catch (err) {
+            log.error('Recovery code rotation failed:', err.message);
+            return { success: false, error: err.message };
+        }
+    }
+
+    /**
+     * Resets password using a recovery code.
+     * @param {string} username - Account username
+     * @param {string} recoveryCode - One-time recovery code
+     * @param {string} newPassword - New password
+     * @returns {Promise<Object>} { success, error? }
+     */
+    async function recoverPassword(username, recoveryCode, newPassword) {
+        if (!apiFeaturesEnabled) {
+            return getApiDisabledResult();
+        }
+        try {
+            const res = await fetch(`${API_BASE}/auth/recover`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ username, recovery_code: recoveryCode, new_password: newPassword })
+            });
+            const data = await res.json().catch(() => ({}));
+            if (!res.ok) {
+                return { success: false, error: data.error || `HTTP ${res.status}` };
+            }
+            return { success: true };
+        } catch (err) {
+            log.error('Password recovery failed:', err.message);
+            return { success: false, error: err.message };
+        }
     }
 
     // --- Public API ---
@@ -647,11 +840,20 @@ const TardAPI = (function() {
         clearSession,
         setApiFeaturesEnabled,
 
+        // Account / auth
+        login,
+        register,
+        logout,
+        checkAuth,
+        rotateRecoveryCodes,
+        recoverPassword,
+
         // Utilities
         checkApiStatus,
         getGameState,
         computeSHA256,
         computePoWProof,
+        isSessionInvalidError,
 
         // State getters
         get sessionId() { return sessionId; },
@@ -659,6 +861,8 @@ const TardAPI = (function() {
         get hasActiveSession() { return !!sessionId; },
         get hasChallenge() { return !!challengeData; },
         get challenge() { return challengeData; },
+        get isLoggedIn() { return !!authUsername; },
+        get username() { return authUsername; },
 
         // Debug
         debug: {

--- a/src/scripts/tardboard.js
+++ b/src/scripts/tardboard.js
@@ -1,14 +1,13 @@
 // ============================================================================
-// TardBoard (Leaderboard + Captcha Integration)
+// TardBoard (Leaderboard + PoW Integration)
 // ============================================================================
 
 /**
- * @fileoverview TardBoard - Leaderboard and Captcha Integration System for TardQuest
+ * @fileoverview TardBoard - Leaderboard Integration System for TardQuest
  *
- * This module provides a comprehensive leaderboard system with captcha verification
- * for highscore submissions. It includes:
+ * This module provides a comprehensive leaderboard system with proof-of-work
+ * verification for highscore submissions. It includes:
  *
- * - Cloudflare Turnstile captcha integration for bot protection
  * - Modal dialog system for user interaction
  * - Automatic game state monitoring and reporting via TardAPI
  * - Highscore submission with validation
@@ -19,10 +18,10 @@
  * 2. Monitoring game progress (floor/level changes) via TardAPI
  * 3. Intercepting game resets to show leaderboard submission dialog
  * 4. Validating sessions before allowing highscore submissions
- * 5. Using captcha to prevent automated submissions
+ * 5. Using server-issued proof-of-work challenges to prevent automated submissions
  *
  * Dependencies:
- * - tardAPI.js (for session management and progress updates)
+ * - tardAPI.js (for session management, progress updates, and PoW challenges)
  */
 // --- Logging Utility ---
 
@@ -44,40 +43,6 @@ if (typeof TardAPI === 'undefined') {
 }
 
 // --- Constants --------------------------------------
-
-/** @type {Promise|null} Promise that resolves when Turnstile script is loaded */
-let _turnstileReadyPromise = null;
-
-/** @const {string} Cloudflare Turnstile site key for captcha verification */
-const TURNSTILE_SITE_KEY = '0x4AAAAAABzv0mtUXvveSKgW';
-
-/**
- * Ensures the Cloudflare Turnstile captcha script is loaded and ready
- * @returns {Promise} Promise that resolves when Turnstile is available
- */
-function ensureTurnstileScript() {
-    if (_turnstileReadyPromise) return _turnstileReadyPromise;
-    _turnstileReadyPromise = new Promise((resolve, reject) => {
-        if (window.turnstile && typeof window.turnstile.render === 'function') return resolve();
-        const existing = document.querySelector('script[data-turnstile-loaded]');
-        if (existing) {
-            const check = setInterval(() => {
-                if (window.turnstile && typeof window.turnstile.render === 'function') { clearInterval(check); resolve(); }
-            }, 100);
-            setTimeout(() => { clearInterval(check); if (!(window.turnstile && window.turnstile.render)) reject(new Error('Turnstile script timeout')); }, 10000);
-            return;
-        }
-        const s = document.createElement('script');
-        s.src = 'https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit';
-        s.async = true; s.defer = true; s.setAttribute('data-turnstile-loaded', '1');
-        s.onload = () => (window.turnstile && typeof window.turnstile.render === 'function') ? resolve() : reject(new Error('Turnstile global missing after load'));
-        s.onerror = () => reject(new Error('Failed to load Turnstile script'));
-        document.head.appendChild(s);
-        const poll = setInterval(() => { if (window.turnstile && typeof window.turnstile.render === 'function') { clearInterval(poll); resolve(); } }, 120);
-        setTimeout(() => clearInterval(poll), 10000);
-    });
-    return _turnstileReadyPromise;
-}
 
 // --- State ------------------------------------------------------------------
 
@@ -159,9 +124,6 @@ function createDialog({ bodyHtml, showApi = true, buttons = [], afterRender }) {
             ${showApi ? `<div class="tardboard-api"><span id="tardboard-title">🏆 TardBoard: </span><span id="tardboard-api-status" style="color:#aaa;font-size:.95em;">Checking API...</span></div>` : ''}
             <div class="tardboard-body" style="color:#fff;">${bodyHtml}</div>
             <div class="tardboard-buttons"></div>
-            <div id="hcaptcha-wrapper" style="position:absolute;left:-9999px;top:-9999px;width:1px;height:1px;overflow:hidden;">
-                <div id="hcaptcha-container"></div>
-            </div>
         </div>`;
     document.body.appendChild(wrap);
     const btnContainer = wrap.querySelector('.tardboard-buttons');
@@ -189,12 +151,10 @@ function removeDialog() {
 // --- Dialog / Submission Flow ----------------------------------------------
 
 /**
- * Shows the initials entry dialog with captcha verification
+ * Shows the initials entry dialog
  * @param {Function} submitCallback - Callback function called with submission data or null
  */
 function showInitialsDialog(submitCallback) {
-    let widgetId = null;
-    let captchaToken = null;
     let pendingSubmit = false;
             createDialog({
             bodyHtml: `Enter your initials (up to 5)<br><br>
@@ -227,7 +187,7 @@ function showInitialsDialog(submitCallback) {
 
     let initialsValue = '';
     function proceedIfReady() {
-        if (!pendingSubmit || !captchaToken) return;
+        if (!pendingSubmit) return;
         removeDialog();
         let val = initialsValue.trim().toUpperCase();
         if (!val) {
@@ -236,29 +196,9 @@ function showInitialsDialog(submitCallback) {
             window.location.reload();
         } else {
             // log.debug('Submitting initials:', val);
-            submitCallback({ initials: val, captcha: captchaToken });
+            submitCallback({ initials: val });
         }
     }
-
-    function onCaptchaSuccess(token) {
-        captchaToken = token;
-        log.info('Captcha verified');
-        proceedIfReady();
-    }
-
-    ensureTurnstileScript()
-        .then(() => {
-            try {
-                widgetId = window.turnstile.render('#hcaptcha-container', {
-                    sitekey: TURNSTILE_SITE_KEY,
-                    size: 'invisible',
-                    callback: onCaptchaSuccess,
-                    'error-callback': () => log.warn('Captcha error'),
-                    'timeout-callback': () => log.warn('Captcha timeout')
-                });
-            } catch { log.error('Captcha render error'); }
-        })
-        .catch(err => { log.error('Turnstile load failure', err); });
 
     const input = document.getElementById('tardboard-initials-input');
     // Build slot overlay for visual feedback
@@ -307,18 +247,14 @@ function showInitialsDialog(submitCallback) {
         const val = input.value.trim();
         if (!val) { alert('Enter initials first.'); return; }
         pendingSubmit = true;
-        // Grey out the Submit button if validation is pending
+        // Grey out the Submit button while submission is in progress
         const okBtn = document.getElementById('tardboard-dialog-ok');
         if (okBtn) {
             okBtn.disabled = true;
             okBtn.style.opacity = '0.5';
             okBtn.style.pointerEvents = 'none';
         }
-        if (captchaToken) { proceedIfReady(); return; }
-        // log.debug('Verifying captcha...');
-        if (window.turnstile && widgetId !== null) {
-            try { window.turnstile.execute(widgetId); } catch { log.error('Captcha error'); }
-        } else log.warn('Captcha unavailable');
+        proceedIfReady();
     }
     function onCancel() {
         removeDialog();
@@ -374,13 +310,12 @@ function showValidationFailDialog(reason) {
 /**
  * Validates anti-cheat session and submits highscore to leaderboard
  * @param {string} playerInitials - Player's initials (max 5 characters)
- * @param {string} captchaToken - Captcha verification token
  */
-async function submitHighscore(playerInitials, captchaToken) {
+async function submitHighscore(playerInitials) {
     showSubmissionLoadingDialog();
     try {
         // Use TardAPI to submit the score with PoW proof if available
-        const result = await TardAPI.submitScore(playerInitials, { captcha_token: captchaToken });
+        const result = await TardAPI.submitScore(playerInitials);
         removeDialog();
 
         if (result.success) {
@@ -421,7 +356,7 @@ async function submitHighscore(playerInitials, captchaToken) {
             const replacement = function() {
                 if (typeof window._inputBlocked !== 'undefined') window._inputBlocked = false;
                 showInitialsDialog(data => {
-                    if (data && data.initials) submitHighscore(data.initials, data.captcha);
+                    if (data && data.initials) submitHighscore(data.initials);
                 });
             };
             return originalSetTimeout(replacement, delay);


### PR DESCRIPTION
This pull request introduces several major improvements to the API integration and authentication system. It updates all API endpoints to use new base URLs, adds a comprehensive account authentication system (including login, registration, recovery, and session management), and improves session state handling and error detection.

**API Endpoint Updates**
- All API calls in `tardAPI.js` and `pigeon.js` now use the new gateway URL and updated endpoint paths (e.g., `/start`, `/leaderboard`, `/status`), removing the `/api/` prefix.

**Authentication & Account Management (future use)**
- Introduced a full account system with methods for login, registration, logout, session checking, password recovery, and recovery code rotation. Integrates with your TardQuest Online account and supports rolling leaderboard updates.

**Miscellaneous Enhancements**
- Refactored PoW challenge storage into a dedicated helper function.

**API Server Updates**
- For information on the v4 server, please see [the documentation.](https://github.com/VocaPepper/tardquest-api/blob/4.0/docs/public/README.md)
- New Endpoint: `gateway.tardquest.online` replaces `vocapepper.com:9601`
- Old endpoint URLs automatically redirect to new server
- Client versions as low as 1.19.2 include limited API support. Leaderboard submissions will not be accepted on clients older than 4.0.2606